### PR TITLE
Fix clahe and cllcn

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkPixelNormalizeN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkPixelNormalizeN5.java
@@ -147,6 +147,7 @@ public class SparkPixelNormalizeN5 {
 		final N5Reader n5Input = new N5FSReader(n5PathInput);
 		final N5Writer n5Output = new N5FSWriter(n5PathOutput);
 
+		final int[] gridBlockSize = Arrays.stream(gridBlock[1]).mapToInt(i -> (int)i).toArray();
 		final FinalInterval gridBlockInterval;
 		
 		if ( blockSize.length == 3 )
@@ -171,7 +172,7 @@ public class SparkPixelNormalizeN5 {
 			source = invert ?
 				Converters.convertRAI(sourceRaw, (in, out) -> { if (in.get() == 0) { out.set(0 ); } else { out.set(255 - in.get() );} }, new FloatType() ) : sourceRaw;
 
-			final RandomAccessibleInterval<FloatType> filteredSource = normalizeContrast(source, new FloatType(), normalizeMethod, scaleIndex, blockSize);
+			final RandomAccessibleInterval<FloatType> filteredSource = normalizeContrast(source, new FloatType(), normalizeMethod, scaleIndex, gridBlockSize);
 
 			N5Utils.saveNonEmptyBlock(Views.interval(filteredSource, gridBlockInterval),
 					  n5Output,
@@ -188,7 +189,7 @@ public class SparkPixelNormalizeN5 {
 			source = invert ?
 					Converters.convertRAI(sourceRaw, (in, out) -> { if (in.get() == 0) { out.set(0 ); } else { out.set(255 - in.get() );} }, new UnsignedByteType() ) : sourceRaw;
 
-			final RandomAccessibleInterval<UnsignedByteType> filteredSource = normalizeContrast(source,  new UnsignedByteType(), normalizeMethod, scaleIndex, blockSize);
+			final RandomAccessibleInterval<UnsignedByteType> filteredSource = normalizeContrast(source,  new UnsignedByteType(), normalizeMethod, scaleIndex, gridBlockSize);
 
 			N5Utils.saveNonEmptyBlock(Views.interval(filteredSource, gridBlockInterval),
 					  n5Output,

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/ops/CLLCN.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/ops/CLLCN.java
@@ -36,11 +36,6 @@ public class CLLCN extends BlockStatistics {
 //	f(x, a, b) = x < b ? x : (x - b + g(a))**a + b - g(a)**a
 
 
-	/**
-	 *
-	 * @param ip
-	 * @param v
-	 */
 	public void runCenter(
 			final int blockRadiusX,
 			final int blockRadiusY) {
@@ -62,7 +57,7 @@ public class CLLCN extends BlockStatistics {
 			for (int x = 0; x < width; ++x) {
 				final int xMin = Math.max(-1, x - blockRadiusX - 1);
 				final int xMax = Math.min(w, x + blockRadiusX);
-				final long bs = (xMax - xMin) * bh;
+				final double bs = (xMax - xMin) * bh;
 				final double scale = 1.0 / bs;
 				final double sum = sums.getDoubleSum(xMin, yMin, xMax, yMax);
 				final int i = row + x;
@@ -75,11 +70,6 @@ public class CLLCN extends BlockStatistics {
 		}
 	}
 
-	/**
-	 *
-	 * @param ip
-	 * @param v
-	 */
 	public void runStretch(
 			final int blockRadiusX,
 			final int blockRadiusY,
@@ -102,7 +92,7 @@ public class CLLCN extends BlockStatistics {
 			for (int x = 0; x < width; ++x) {
 				final int xMin = Math.max(-1, x - blockRadiusX - 1);
 				final int xMax = Math.min(w, x + blockRadiusX);
-				final long bs = (xMax - xMin) * bh;
+				final double bs = (xMax - xMin) * bh;
 				final double scale1 = 1.0 / (bs - 1);
 				final double scale2 = 1.0 / (bs * bs - bs);
 				final double sum = sums.getDoubleSum(xMin, yMin, xMax, yMax);
@@ -131,11 +121,6 @@ public class CLLCN extends BlockStatistics {
 		return x < limit ? x : Math.pow(x + gradientOnePointMinusLimit, gamma) + limitMinusGradientOnePointPowGamma;
 	}
 
-	/**
-	 *
-	 * @param ip
-	 * @param v
-	 */
 	public void runStretch(
 			final int blockRadiusX,
 			final int blockRadiusY,
@@ -164,7 +149,7 @@ public class CLLCN extends BlockStatistics {
 			for (int x = 0; x < width; ++x) {
 				final int xMin = Math.max(-1, x - blockRadiusX - 1);
 				final int xMax = Math.min(w, x + blockRadiusX);
-				final long bs = (xMax - xMin) * bh;
+				final double bs = (xMax - xMin) * bh;
 				final double scale1 = 1.0 / (bs - 1);
 				final double scale2 = 1.0 / (bs * bs - bs);
 				final double sum = sums.getDoubleSum(xMin, yMin, xMax, yMax);
@@ -187,11 +172,6 @@ public class CLLCN extends BlockStatistics {
 	}
 
 
-	/**
-	 *
-	 * @param ip
-	 * @param v
-	 */
 	protected void runCenterStretch(
 			final int blockRadiusX,
 			final int blockRadiusY,
@@ -213,7 +193,7 @@ public class CLLCN extends BlockStatistics {
 			for (int x = 0; x < width; ++x) {
 				final int xMin = Math.max(-1, x - blockRadiusX - 1);
 				final int xMax = Math.min(w, x + blockRadiusX);
-				final long bs = (xMax - xMin) * bh;
+				final double bs = (xMax - xMin) * bh;
 				final double scale = 1.0 / bs;
 				final double scale1 = 1.0 / (bs - 1);
 				final double scale2 = 1.0 / (bs * bs - bs);
@@ -233,11 +213,6 @@ public class CLLCN extends BlockStatistics {
 	}
 
 
-	/**
-	 *
-	 * @param ip
-	 * @param v
-	 */
 	protected void runCenterStretch(
 			final int blockRadiusX,
 			final int blockRadiusY,
@@ -267,7 +242,7 @@ public class CLLCN extends BlockStatistics {
 			for (int x = 0; x < width; ++x) {
 				final int xMin = Math.max(-1, x - blockRadiusX - 1);
 				final int xMax = Math.min(w, x + blockRadiusX);
-				final long bs = (xMax - xMin) * bh;
+				final double bs = (xMax - xMin) * bh;
 				final double scale = 1.0 / bs;
 				final double scale1 = 1.0 / (bs - 1);
 				final double scale2 = 1.0 / (bs * bs - bs);
@@ -298,11 +273,6 @@ public class CLLCN extends BlockStatistics {
 	}
 
 
-	/**
-	 *
-	 * @param ip
-	 * @param v
-	 */
 	public void run(
 			final int blockRadiusX,
 			final int blockRadiusY,


### PR DESCRIPTION
This PR fixes the inefficient computation of the CLAHE and CLLCN filters.

The fix was to change the block size of the lazily generated output from the output block size (smaller) to the compute block size (larger). This results in the compute context being considered only once per compute block instead of once per output block, reducing the number of redundant computations.

For an output block size of `(128, 128, ...)` and a comput block size of `(1024, 1024, ...)`, the speedup is about 10x. I checked that this produces the same result before and after the change.