### PR TITLE
Improve multi-sem normalization

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
@@ -1,0 +1,150 @@
+package org.janelia.saalfeldlab.hotknife;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
+
+import mpicbg.models.AffineModel1D;
+
+import org.janelia.saalfeldlab.hotknife.util.N5Util;
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+
+/**
+ * Layer-wise intensity normalization for FIB-SEM data.
+ * Uses all non-zero pixels without masking. Supports both shift and scale transformations.
+ *
+ * @param <T> pixel type (8bit or 16bit)
+ */
+public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType<T>> extends SparkNormalizeLayerIntensityN5<T> {
+
+	@SuppressWarnings({"FieldMayBeFinal", "unused"})
+	protected static class Options extends SparkNormalizeLayerIntensityN5.Options implements Serializable {
+
+		@Option(name = "--shift",
+				usage = "Shift intensities based on the given statistic: 'NONE', 'MEDIAN', or 'MEAN'")
+		private ShiftType shift = ShiftType.MEAN;
+
+		@Option(name = "--scale",
+				usage = "Scale intensities based on the given method: 'NONE', 'FULL_RANGE', or 'GAUSS'")
+		private ScaleType scale = ScaleType.NONE;
+
+		@Option(name = "--cutoff",
+				usage = "Cut this fraction of pixels on either side when computing the layer statistics (default: 0.03)")
+		private double cutoff = 0.03;
+
+		protected Options(final String[] args) {
+			final CmdLineParser parser = new CmdLineParser(this);
+			try {
+				parser.parseArgument(args);
+				parsedSuccessfully = true;
+			} catch (final Exception e) {
+				e.printStackTrace(System.err);
+				parser.printUsage(System.err);
+			}
+		}
+
+		protected ShiftType shift() {
+			return shift;
+		}
+
+		protected ScaleType scale() {
+			return scale;
+		}
+
+		protected double cutoff() {
+			return cutoff;
+		}
+	}
+
+	public static void main(final String... args) throws IOException, InterruptedException, ExecutionException {
+
+		final Options options = new Options(args);
+		if (!options.parsedSuccessfully) {
+			throw new IllegalArgumentException("Options were not parsed successfully");
+		}
+
+		final DatasetAttributes attributes;
+		try (final N5Reader n5reader = N5Util.createN5Reader(options.n5Path())) {
+			if (n5reader.exists(options.n5DatasetOutput())) {
+				throw new IllegalArgumentException("Normalized data set already exists: " + options.n5DatasetOutput());
+			}
+
+			final String fullScaleInputDataset = options.n5DatasetInput() + "/s0";
+			attributes = n5reader.getDatasetAttributes(fullScaleInputDataset);
+			if (attributes == null) {
+				throw new IllegalArgumentException("no attributes found in " + options.n5Path() + fullScaleInputDataset);
+			}
+		}
+
+		if (attributes.getDataType() == DataType.UINT8) {
+			new FibSemNormalizeLayerIntensity<>(options, attributes, new ByteHelper()).run();
+		} else if (attributes.getDataType() == DataType.UINT16) {
+			new FibSemNormalizeLayerIntensity<>(options, attributes, new ShortHelper()).run();
+		} else {
+			throw new IllegalArgumentException("Unsupported data type: " + attributes.getDataType());
+		}
+	}
+
+	private final Options fibSemOptions;
+
+	private FibSemNormalizeLayerIntensity(final Options options, final DatasetAttributes attributes, final TypeHelper<T> typeHelper) {
+		super(options, attributes, typeHelper);
+		this.fibSemOptions = options;
+	}
+
+	@Override
+	protected List<AffineModel1D> computeTransformations(final RandomAccessibleInterval<T> rai) {
+		final List<IntervalView<T>> stack = asZStack(rai);
+		final List<LayerStats> layerStats = new ArrayList<>(stack.size());
+
+		// Compute statistics for each layer using all non-zero pixels
+		for (final IntervalView<T> layer : stack) {
+			final List<Double> pixels = new ArrayList<>();
+			for (final T pixel : Views.flatIterable(layer)) {
+				if (pixel.getInteger() > 0) {
+					pixels.add((double) pixel.getInteger());
+				}
+			}
+
+			final double[] arr = pixels.stream().mapToDouble(Double::doubleValue).toArray();
+			layerStats.add(LayerStats.from(arr, fibSemOptions.cutoff()));
+		}
+
+		// Determine the target shift and scale based on the layer with the maximum scale
+		// which maximizes the expressive range while minimizing the risk of clipping
+		final int maxScaleIndex = IntStream.range(0, layerStats.size())
+				.boxed()
+				.max(Comparator.comparingDouble(i -> fibSemOptions.scale().get(layerStats.get(i))))
+				.orElseThrow(NoSuchElementException::new);
+		final double targetShift = fibSemOptions.shift().from(layerStats.get(maxScaleIndex));
+		final double targetScale = fibSemOptions.scale().get(layerStats.get(maxScaleIndex));
+
+		// Compute intensity transformations for each layer
+		final List<AffineModel1D> models = new ArrayList<>(stack.size());
+		for (final LayerStats stats : layerStats) {
+			final AffineModel1D model = new AffineModel1D();
+			final double scale = targetScale / fibSemOptions.scale().get(stats);
+			final double shift = targetShift - fibSemOptions.shift().from(stats) * scale;
+			model.set(scale, shift);
+			models.add(model);
+		}
+
+		return models;
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
@@ -11,10 +11,8 @@ import java.util.stream.IntStream;
 
 import mpicbg.models.AffineModel1D;
 
-import org.janelia.saalfeldlab.hotknife.util.N5Util;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.N5Reader;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
@@ -44,10 +42,6 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 				usage = "Scale intensities based on the given method: 'NONE', 'FULL_RANGE', or 'GAUSS'")
 		private ScaleType scale = ScaleType.NONE;
 
-		@Option(name = "--cutoff",
-				usage = "Cut this fraction of pixels on either side when computing the layer statistics (default: 0.03)")
-		private double cutoff = 0.03;
-
 		protected Options(final String[] args) {
 			final CmdLineParser parser = new CmdLineParser(this);
 			try {
@@ -66,10 +60,6 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 		protected ScaleType scale() {
 			return scale;
 		}
-
-		protected double cutoff() {
-			return cutoff;
-		}
 	}
 
 	public static void main(final String... args) throws IOException, InterruptedException, ExecutionException {
@@ -79,18 +69,7 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 			throw new IllegalArgumentException("Options were not parsed successfully");
 		}
 
-		final DatasetAttributes attributes;
-		try (final N5Reader n5reader = N5Util.createN5Reader(options.n5Path())) {
-			if (n5reader.exists(options.n5DatasetOutput())) {
-				throw new IllegalArgumentException("Normalized data set already exists: " + options.n5DatasetOutput());
-			}
-
-			final String fullScaleInputDataset = options.n5DatasetInput() + "/s0";
-			attributes = n5reader.getDatasetAttributes(fullScaleInputDataset);
-			if (attributes == null) {
-				throw new IllegalArgumentException("no attributes found in " + options.n5Path() + fullScaleInputDataset);
-			}
-		}
+		final DatasetAttributes attributes = options.readDatasetAttributes();
 
 		if (attributes.getDataType() == DataType.UINT8) {
 			new FibSemNormalizeLayerIntensity<>(options, attributes, new ByteHelper()).run();
@@ -121,9 +100,7 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 					pixels.add((double) pixel.getInteger());
 				}
 			}
-
-			final double[] arr = pixels.stream().mapToDouble(Double::doubleValue).toArray();
-			layerStats.add(LayerStats.from(arr, fibSemOptions.cutoff()));
+			layerStats.add(LayerStats.from(pixels, fibSemOptions.cutoff()));
 		}
 
 		// Determine the target shift and scale based on the layer with the maximum scale

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
@@ -93,14 +93,19 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 		final List<LayerStats> layerStats = new ArrayList<>(stack.size());
 
 		// Compute statistics for each layer using all non-zero pixels
-		for (final IntervalView<T> layer : stack) {
+		System.out.println("Computing layer statistics...");
+		System.out.println("layer\tmedian\tmean\tstd\tmin\tmax");
+		for (int z = 0; z < stack.size(); z++) {
 			final List<Double> pixels = new ArrayList<>();
-			for (final T pixel : Views.flatIterable(layer)) {
+			for (final T pixel : Views.flatIterable(stack.get(z))) {
 				if (pixel.getInteger() > 0) {
 					pixels.add((double) pixel.getInteger());
 				}
 			}
-			layerStats.add(LayerStats.from(pixels, fibSemOptions.cutoff()));
+			final LayerStats stats = LayerStats.from(pixels, fibSemOptions.cutoff());
+			layerStats.add(stats);
+			System.out.printf("%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f%n",
+					z, stats.median, stats.mean, stats.std, stats.min, stats.max);
 		}
 
 		// Determine the target shift and scale based on the layer with the maximum scale
@@ -111,10 +116,13 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 				.orElseThrow(NoSuchElementException::new);
 		final double targetShift = fibSemOptions.shift().from(layerStats.get(maxScaleIndex));
 		final double targetScale = fibSemOptions.scale().get(layerStats.get(maxScaleIndex));
+		System.out.printf("Target layer: %d, targetShift: %.2f, targetScale: %.2f%n",
+				maxScaleIndex, targetShift, targetScale);
 
 		// Compute intensity transformations for each layer
 		final List<AffineModel1D> models = new ArrayList<>(stack.size());
-		for (final LayerStats stats : layerStats) {
+		for (int z = 0; z < layerStats.size(); z++) {
+			final LayerStats stats = layerStats.get(z);
 			final AffineModel1D model = new AffineModel1D();
 			final double scale = targetScale / fibSemOptions.scale().get(stats);
 			final double shift = targetShift - fibSemOptions.shift().from(stats) * scale;

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
@@ -3,16 +3,13 @@ package org.janelia.saalfeldlab.hotknife;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import mpicbg.models.AffineModel1D;
 
-import org.janelia.saalfeldlab.hotknife.util.N5Util;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.N5Reader;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
@@ -41,7 +38,7 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 		MEAN
 	}
 
-	@SuppressWarnings({"FieldMayBeFinal", "unused"})
+	@SuppressWarnings({"FieldMayBeFinal", "unused", "FieldCanBeLocal"})
 	public static class Options extends SparkNormalizeLayerIntensityN5.Options implements Serializable {
 
 		@Option(name = "--aggregation",
@@ -67,15 +64,15 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 			}
 		}
 
-		public AggregationType getAggregation() {
+		public AggregationType aggregation() {
 			return aggregation;
 		}
 
-		public int getLowerThreshold() {
+		public int lowerThreshold() {
 			return lowerThreshold;
 		}
 
-		public int getUpperThreshold() {
+		public int upperThreshold() {
 			return upperThreshold;
 		}
 	}
@@ -87,18 +84,7 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 			throw new IllegalArgumentException("Options were not parsed successfully");
 		}
 
-		final DatasetAttributes attributes;
-		try (final N5Reader n5reader = N5Util.createN5Reader(options.n5Path())) {
-			if (n5reader.exists(options.n5DatasetOutput())) {
-				throw new IllegalArgumentException("Normalized data set already exists: " + options.n5DatasetOutput());
-			}
-
-			final String fullScaleInputDataset = options.n5DatasetInput() + "/s0";
-			attributes = n5reader.getDatasetAttributes(fullScaleInputDataset);
-			if (attributes == null) {
-				throw new IllegalArgumentException("no attributes found in " + options.n5Path() + fullScaleInputDataset);
-			}
-		}
+		final DatasetAttributes attributes = options.readDatasetAttributes();
 
 		if (attributes.getDataType() != DataType.UINT8) {
 			throw new IllegalArgumentException("MultiSemNormalizeLayerIntensity only supports 8-bit data, found: " + attributes.getDataType());
@@ -146,7 +132,7 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 				}
 			}
 
-			// Compute median or mean of shifts
+			// Use LayerStats for robust aggregation with cutoff
 			final double layerShift = aggregateShifts(shifts);
 			cumulativeShift += layerShift;
 
@@ -160,7 +146,7 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 	}
 
 	private boolean isWithinThreshold(final int value) {
-		return value >= multiSemOptions.getLowerThreshold() && value <= multiSemOptions.getUpperThreshold();
+		return value >= multiSemOptions.lowerThreshold() && value <= multiSemOptions.upperThreshold();
 	}
 
 	private double aggregateShifts(final List<Double> shifts) {
@@ -168,13 +154,13 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 			return 0.0;
 		}
 
-		final double[] arr = shifts.stream().mapToDouble(Double::doubleValue).toArray();
-		Arrays.sort(arr);
+		// Use LayerStats for robust aggregation with cutoff (clips outliers)
+		final LayerStats stats = LayerStats.from(shifts, multiSemOptions.cutoff());
 
-		if (multiSemOptions.getAggregation() == AggregationType.MEDIAN) {
-			return arr[arr.length / 2];
+		if (multiSemOptions.aggregation() == AggregationType.MEDIAN) {
+			return stats.median;
 		} else {
-			return Arrays.stream(arr).average().orElse(0.0);
+			return stats.mean;
 		}
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
@@ -1,0 +1,180 @@
+package org.janelia.saalfeldlab.hotknife;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import mpicbg.models.AffineModel1D;
+
+import org.janelia.saalfeldlab.hotknife.util.N5Util;
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.view.IntervalView;
+import net.imglib2.view.Views;
+
+
+/**
+ * Layer-wise intensity normalization for multi-SEM data with non-flat substrate boundaries.
+ * Computes intensity shifts between adjacent layers, using only pixels where both layers
+ * have valid tissue (within threshold). This naturally handles non-flat substrate boundaries
+ * by excluding pixel pairs where one is substrate.
+ * <p>
+ * Only supports 8-bit data and shift transformations (no scaling).
+ */
+public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensityN5<UnsignedByteType> {
+
+	/**
+	 * Aggregation method for computing the shift between adjacent layers.
+	 */
+	public enum AggregationType {
+		MEDIAN,
+		MEAN
+	}
+
+	@SuppressWarnings({"FieldMayBeFinal", "unused"})
+	public static class Options extends SparkNormalizeLayerIntensityN5.Options implements Serializable {
+
+		@Option(name = "--aggregation",
+				usage = "Aggregation method for shift computation: 'MEDIAN' (default, more robust) or 'MEAN'")
+		private AggregationType aggregation = AggregationType.MEDIAN;
+
+		@Option(name = "--lowerThreshold",
+				usage = "Lower intensity threshold for valid tissue pixels (default: 20)")
+		private int lowerThreshold = 20;
+
+		@Option(name = "--upperThreshold",
+				usage = "Upper intensity threshold for valid tissue pixels (default: 200)")
+		private int upperThreshold = 200;
+
+		public Options(final String[] args) {
+			final CmdLineParser parser = new CmdLineParser(this);
+			try {
+				parser.parseArgument(args);
+				parsedSuccessfully = true;
+			} catch (final Exception e) {
+				e.printStackTrace(System.err);
+				parser.printUsage(System.err);
+			}
+		}
+
+		public AggregationType getAggregation() {
+			return aggregation;
+		}
+
+		public int getLowerThreshold() {
+			return lowerThreshold;
+		}
+
+		public int getUpperThreshold() {
+			return upperThreshold;
+		}
+	}
+
+	public static void main(final String... args) throws IOException, InterruptedException, ExecutionException {
+
+		final Options options = new Options(args);
+		if (!options.parsedSuccessfully) {
+			throw new IllegalArgumentException("Options were not parsed successfully");
+		}
+
+		final DatasetAttributes attributes;
+		try (final N5Reader n5reader = N5Util.createN5Reader(options.n5Path())) {
+			if (n5reader.exists(options.n5DatasetOutput())) {
+				throw new IllegalArgumentException("Normalized data set already exists: " + options.n5DatasetOutput());
+			}
+
+			final String fullScaleInputDataset = options.n5DatasetInput() + "/s0";
+			attributes = n5reader.getDatasetAttributes(fullScaleInputDataset);
+			if (attributes == null) {
+				throw new IllegalArgumentException("no attributes found in " + options.n5Path() + fullScaleInputDataset);
+			}
+		}
+
+		if (attributes.getDataType() != DataType.UINT8) {
+			throw new IllegalArgumentException("MultiSemNormalizeLayerIntensity only supports 8-bit data, found: " + attributes.getDataType());
+		}
+
+		new MultiSemNormalizeLayerIntensity(options, attributes).run();
+	}
+
+	private final Options multiSemOptions;
+
+	private MultiSemNormalizeLayerIntensity(final Options options, final DatasetAttributes attributes) {
+		super(options, attributes, new ByteHelper());
+		this.multiSemOptions = options;
+	}
+
+	@Override
+	protected List<AffineModel1D> computeTransformations(final RandomAccessibleInterval<UnsignedByteType> rai) {
+		final List<IntervalView<UnsignedByteType>> stack = asZStack(rai);
+		final List<AffineModel1D> models = new ArrayList<>(stack.size());
+
+		// First layer has identity transform (reference)
+		final AffineModel1D identity = new AffineModel1D();
+		identity.set(1.0, 0.0);
+		models.add(identity);
+
+		double cumulativeShift = 0.0;
+
+		// Compute shifts between adjacent layers
+		for (int z = 0; z < stack.size() - 1; z++) {
+			final IntervalView<UnsignedByteType> currentLayer = stack.get(z);
+			final IntervalView<UnsignedByteType> nextLayer = stack.get(z + 1);
+
+			// Collect valid shifts between adjacent layers
+			final List<Double> shifts = new ArrayList<>();
+			final Cursor<UnsignedByteType> cursorCurrent = Views.flatIterable(currentLayer).cursor();
+			final Cursor<UnsignedByteType> cursorNext = Views.flatIterable(nextLayer).cursor();
+
+			while (cursorCurrent.hasNext()) {
+				final int valCurrent = cursorCurrent.next().getInteger();
+				final int valNext = cursorNext.next().getInteger();
+
+				// Only record shift if BOTH pixels are within threshold (valid tissue)
+				if (isWithinThreshold(valCurrent) && isWithinThreshold(valNext)) {
+					shifts.add((double) (valNext - valCurrent));
+				}
+			}
+
+			// Compute median or mean of shifts
+			final double layerShift = aggregateShifts(shifts);
+			cumulativeShift += layerShift;
+
+			// Create model: new_val = old_val - cumulativeShift (to normalize to layer 0)
+			final AffineModel1D model = new AffineModel1D();
+			model.set(1.0, -cumulativeShift);
+			models.add(model);
+		}
+
+		return models;
+	}
+
+	private boolean isWithinThreshold(final int value) {
+		return value >= multiSemOptions.getLowerThreshold() && value <= multiSemOptions.getUpperThreshold();
+	}
+
+	private double aggregateShifts(final List<Double> shifts) {
+		if (shifts.isEmpty()) {
+			return 0.0;
+		}
+
+		final double[] arr = shifts.stream().mapToDouble(Double::doubleValue).toArray();
+		Arrays.sort(arr);
+
+		if (multiSemOptions.getAggregation() == AggregationType.MEDIAN) {
+			return arr[arr.length / 2];
+		} else {
+			return Arrays.stream(arr).average().orElse(0.0);
+		}
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
@@ -112,6 +112,11 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 
 		double cumulativeShift = 0.0;
 
+		// Print header for diagnostic output
+		System.out.println("Computing layer shift statistics...");
+		System.out.println("layer\tnValid\tmedian\tmean\tstd\tmin\tmax\tlayerShift\tcumulativeShift");
+		System.out.printf("%d\t-\t-\t-\t-\t-\t-\t%.2f\t%.2f%n", 0, 0.0, 0.0);
+
 		// Compute shifts between adjacent layers
 		for (int z = 0; z < stack.size() - 1; z++) {
 			final IntervalView<UnsignedByteType> currentLayer = stack.get(z);
@@ -132,9 +137,20 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 				}
 			}
 
-			// Use LayerStats for robust aggregation with cutoff
-			final double layerShift = aggregateShifts(shifts);
-			cumulativeShift += layerShift;
+			// Compute layer shift using LayerStats for robust aggregation
+			double layerShift = 0.0;
+			if (!shifts.isEmpty()) {
+				final LayerStats stats = LayerStats.from(shifts, multiSemOptions.cutoff());
+				layerShift = (multiSemOptions.aggregation() == AggregationType.MEDIAN) ? stats.median : stats.mean;
+				cumulativeShift += layerShift;
+
+				System.out.printf("%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f%n",
+						z + 1, shifts.size(), stats.median, stats.mean, stats.std, stats.min, stats.max,
+						layerShift, cumulativeShift);
+			} else {
+				System.out.printf("%d\t0\t-\t-\t-\t-\t-\t%.2f\t%.2f%n",
+						z + 1, layerShift, cumulativeShift);
+			}
 
 			// Create model: new_val = old_val - cumulativeShift (to normalize to layer 0)
 			final AffineModel1D model = new AffineModel1D();
@@ -147,20 +163,5 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 
 	private boolean isWithinThreshold(final int value) {
 		return value >= multiSemOptions.lowerThreshold() && value <= multiSemOptions.upperThreshold();
-	}
-
-	private double aggregateShifts(final List<Double> shifts) {
-		if (shifts.isEmpty()) {
-			return 0.0;
-		}
-
-		// Use LayerStats for robust aggregation with cutoff (clips outliers)
-		final LayerStats stats = LayerStats.from(shifts, multiSemOptions.cutoff());
-
-		if (multiSemOptions.aggregation() == AggregationType.MEDIAN) {
-			return stats.median;
-		} else {
-			return stats.mean;
-		}
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
@@ -4,13 +4,9 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
-import java.util.stream.IntStream;
 
 import mpicbg.models.AbstractAffineModel1D;
 import mpicbg.models.AffineModel1D;
@@ -22,22 +18,17 @@ import org.apache.spark.broadcast.Broadcast;
 import org.janelia.saalfeldlab.hotknife.util.Grid;
 import org.janelia.saalfeldlab.hotknife.util.N5PathSupplier;
 import org.janelia.saalfeldlab.hotknife.util.N5Util;
-import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
-import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
-import net.imglib2.Cursor;
 import net.imglib2.FinalInterval;
-import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converters;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
-import net.imglib2.loops.LoopBuilder;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
@@ -51,104 +42,75 @@ import static org.janelia.saalfeldlab.n5.spark.downsample.scalepyramid.N5ScalePy
 
 
 /**
- * Normalize layer intensity in N5 data set. The normalization is done by transforming the intensity of each layer
- * relative to the first layer. The transformations are computed based on a column of pixels that have "content"
- * throughout the stack (i.e. pixels that are not background).
+ * Abstract base class for layer-wise intensity normalization in N5 data sets.
+ * Subclasses implement different normalization strategies for different imaging modalities.
  *
  * @param <T> pixel type, determined automatically from the input stack (either 8bit or 16bit)
  */
-public class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & IntegerType<T>> implements Serializable {
+public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & IntegerType<T>> implements Serializable {
 
+	/**
+	 * Base options class containing common parameters for all normalization strategies.
+	 * Subclasses should extend this with their specific options.
+	 */
 	@SuppressWarnings({"FieldMayBeFinal", "unused"})
 	public static class Options extends AbstractOptions implements Serializable {
 
 		@Option(name = "--n5Path",
 				required = true,
 				usage = "N5 path, e.g. /nrs/hess/data/hess_wafer_53/export/hess_wafer_53b.n5")
-		private String n5Path = null;
+		protected String n5Path = null;
 
 		@Option(name = "--n5DatasetInput",
 				required = true,
 				usage = "Input N5 dataset, e.g. /render/slab_070_to_079/s075_m119_align_big_block_ic___20240308_072106")
-		private String n5DatasetInput = null;
+		protected String n5DatasetInput = null;
 
 		@Option(name = "--n5DatasetOutput",
 				required = true,
 				usage = "Output N5 dataset, e.g. /render/slab_070_to_079/s075_m119_align_big_block_ic___20240308_072106_norm-layer")
-		private String n5DatasetOutput = null;
+		protected String n5DatasetOutput = null;
 
 		@Option(name = "--downsampleLevel",
 				usage = "Take this downsample level for computing the intensity transformations. Note that that downsampling in z is not supported.")
-		private Integer downsampleLevel = 5;
+		protected Integer downsampleLevel = 5;
 
 		@Option(name = "--factors",
 				usage = "If specified, generates a scale pyramid with given factors, e.g. 2,2,1")
 		public String factors;
 
-		@Option(name = "--shift",
-				usage = "Shift intensities based on the given mean: 'NONE', 'MEDIAN', or 'MEAN'")
-		private ShiftType shift = ShiftType.MEAN;
-
-		@Option(name = "--scale",
-				usage = "Scale intensities based on the given method: 'NONE', 'FULL_RANGE', or 'GAUSS'")
-		private ScaleType scale = ScaleType.NONE;
-
-		@Option(name = "--cutoff",
-				usage = "Cut this fraction of pixels on either side when computing the layer statistics (default: 0.03)")
-		private double cutoff = 0.03;
-
-		public Options(final String[] args) {
-			final CmdLineParser parser = new CmdLineParser(this);
-			try {
-				parser.parseArgument(args);
-				parsedSuccessfully = true;
-			} catch (final Exception e) {
-				e.printStackTrace(System.err);
-				parser.printUsage(System.err);
-			}
-		}
-	}
-
-	public static void main(final String... args) throws IOException, InterruptedException, ExecutionException {
-
-		final SparkNormalizeLayerIntensityN5.Options options = new SparkNormalizeLayerIntensityN5.Options(args);
-		if (! options.parsedSuccessfully) {
-			throw new IllegalArgumentException("Options were not parsed successfully");
+		protected Options() {
+			// Default constructor for subclasses
 		}
 
-		final DatasetAttributes attributes;
-		try (final N5Reader n5reader = N5Util.createN5Reader(options.n5Path)) {
-			if (n5reader.exists(options.n5DatasetOutput)) {
-				throw new IllegalArgumentException("Normalized data set already exists: " + options.n5DatasetOutput);
-			}
-
-			final String fullScaleInputDataset = options.n5DatasetInput + "/s0";
-			attributes = n5reader.getDatasetAttributes(fullScaleInputDataset);
-            if (attributes == null) {
-                throw new IllegalArgumentException("no attributes found in " + options.n5Path + fullScaleInputDataset);
-            }
+		public String n5Path() {
+			return n5Path;
 		}
 
-        if (attributes.getDataType() == DataType.UINT8) {
-			new SparkNormalizeLayerIntensityN5<>(options, attributes, new ByteHelper()).run();
-		} else if (attributes.getDataType() == DataType.UINT16) {
-			new SparkNormalizeLayerIntensityN5<>(options, attributes, new ShortHelper()).run();
-		} else {
-			throw new IllegalArgumentException("Unsupported data type: " + attributes.getDataType());
+		public String n5DatasetInput() {
+			return n5DatasetInput;
+		}
+
+		public String n5DatasetOutput() {
+			return n5DatasetOutput;
+		}
+
+		public Integer downsampleLevel() {
+			return downsampleLevel;
 		}
 	}
 
 
 
-	private final String fullScaleInputDataset;
-	private final String downScaledInputDataset;
-	private final String fullScaleOutputDataset;
-	private final Options options;
-	private final DatasetAttributes attributes;
-	private final TypeHelper<T> typeHelper;
+	protected final String fullScaleInputDataset;
+	protected final String downScaledInputDataset;
+	protected final String fullScaleOutputDataset;
+	protected final Options options;
+	protected final DatasetAttributes attributes;
+	protected final TypeHelper<T> typeHelper;
 
 
-	private SparkNormalizeLayerIntensityN5(final Options options, final DatasetAttributes attributes, final TypeHelper<T> typeHelper) {
+	protected SparkNormalizeLayerIntensityN5(final Options options, final DatasetAttributes attributes, final TypeHelper<T> typeHelper) {
 		fullScaleInputDataset = options.n5DatasetInput + "/s0";
 		fullScaleOutputDataset = options.n5DatasetOutput + "/s0";
 		downScaledInputDataset = options.n5DatasetInput + "/s" + options.downsampleLevel;
@@ -157,7 +119,7 @@ public class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & IntegerTyp
 		this.typeHelper = typeHelper;
 	}
 
-	private void run() throws IOException {
+	protected void run() throws IOException {
 		// Compute transformations based on downsampled input
 		final List<AffineModel1D> transformations;
 		try (final N5Reader n5reader = N5Util.createN5Reader(options.n5Path)) {
@@ -201,73 +163,14 @@ public class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & IntegerTyp
 	}
 
 
-	List<AffineModel1D> computeTransformations(
-			final RandomAccessibleInterval<T> rai
-	) {
-
-		// Create mask of xy-pixels that have "content" throughout all z-layers
-		final List<IntervalView<T>> downScaledStack = asZStack(rai);
-		final Img<T> zProjectedContentMask = typeHelper.createImg(downScaledStack.get(0).dimensionsAsLongArray());
-		for (final T pixel : zProjectedContentMask) {
-			pixel.setOne();
-		}
-
-		for (final IntervalView<T> layer : downScaledStack) {
-			LoopBuilder.setImages(layer, zProjectedContentMask)
-					.forEachPixel((a, b) -> {
-						if (typeHelper.isOutsideThreshold(a.getInteger())) {
-							b.setZero();
-						}
-					});
-		}
-
-		final int nContentPixels = (int) zProjectedContentMask.stream()
-				.filter(pixel -> pixel.getInteger() == 1)
-				.count();
-
-		// Compute key statistics for each layer
-		final double[] layerPixels = new double[nContentPixels];
-		final List<LayerStats> layerStats = new ArrayList<>(downScaledStack.size());
-		for (final IntervalView<T> currentLayer : downScaledStack) {
-			extractContentPixels(currentLayer, zProjectedContentMask, layerPixels);
-			final LayerStats stats = LayerStats.from(layerPixels, options.cutoff);
-			layerStats.add(stats);
-		}
-
-		// Determine the target shift and scale based on the layer with the maximum scale
-		// which maximizes the expressive range while minimizing the risk of clipping
-		final int maxScaleIndex = IntStream.range(0, layerStats.size())
-				.boxed()
-				.max(Comparator.comparingDouble(i -> options.scale.get(layerStats.get(i))))
-				.orElseThrow(NoSuchElementException::new);
-		final double targetShift = options.shift.from(layerStats.get(maxScaleIndex));
-		final double targetScale = options.scale.get(layerStats.get(maxScaleIndex));
-
-		// Compute intensity transformations for each layer transforming them to the target scale and shift
-		final List<AffineModel1D> models = new ArrayList<>(downScaledStack.size());
-		for (final LayerStats stats : layerStats) {
-			final AffineModel1D model = new AffineModel1D();
-			final double scale = targetScale / options.scale.get(stats);
-			final double shift = targetShift - options.shift.from(stats) * scale;
-			model.set(scale, shift);
-			models.add(model);
-		}
-
-		return models;
-	}
-
-	private void extractContentPixels(final RandomAccessibleInterval<T> layer, final Img<T> mask, final double[] contentPixels) {
-		final Cursor<T> layerCursor = Views.flatIterable(layer).localizingCursor();
-		final RandomAccess<T> maskAccess = mask.randomAccess();
-		int i = 0;
-		while (layerCursor.hasNext()) {
-			layerCursor.fwd();
-			maskAccess.setPosition(layerCursor);
-			if (maskAccess.get().getInteger() == 1) {
-				contentPixels[i++] = layerCursor.get().getInteger();
-			}
-		}
-	}
+	/**
+	 * Compute the intensity transformations for each layer.
+	 * Subclasses implement different strategies for computing these transformations.
+	 *
+	 * @param rai the downsampled input image
+	 * @return list of affine models, one per layer
+	 */
+	protected abstract List<AffineModel1D> computeTransformations(final RandomAccessibleInterval<T> rai);
 
 	private RandomAccessibleInterval<T> applyTransformations(
 			final RandomAccessibleInterval<T> sourceRaw,
@@ -298,7 +201,7 @@ public class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & IntegerTyp
 		return Views.stack(convertedLayers);
 	}
 
-	private List<IntervalView<T>> asZStack(final RandomAccessibleInterval<T> rai) {
+	protected List<IntervalView<T>> asZStack(final RandomAccessibleInterval<T> rai) {
 		final List<IntervalView<T>> stack = new ArrayList<>((int) rai.dimension(2));
 		for (int z = 0; z < rai.dimension(2); ++z) {
 			stack.add(Views.hyperSlice(rai, 2, z));
@@ -328,7 +231,7 @@ public class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & IntegerTyp
 	/**
 	 * Helper class to hold the median, mean, min and max (discarding some cutoff pixels on either side) of a layer.
 	 */
-	private static class LayerStats {
+	protected static class LayerStats {
 		public final double median;
 		public final double mean;
 		public final double std;
@@ -373,7 +276,7 @@ public class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & IntegerTyp
 	/**
 	 * Small helper enum to represent the type of mean used for normalization.
 	 */
-	private enum ShiftType {
+	protected enum ShiftType {
 		NONE(stats -> 0.0),
 		MEDIAN(stats -> stats.median),
 		MEAN(stats -> stats.mean);
@@ -394,7 +297,7 @@ public class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & IntegerTyp
 	 * Small helper enum to represent the type of scaling used for normalization.
 	 * 'GAUSS' scaling is what is used to normalize 8bit FIB-SEM data.
 	 */
-	private enum ScaleType {
+	protected enum ScaleType {
 		NONE(stats -> 1.0),
 		FULL_RANGE(stats -> stats.max - stats.min),
 		GAUSS(stats -> 4 * stats.std);
@@ -417,14 +320,14 @@ public class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & IntegerTyp
 	 *
 	 * @param <T> the pixel type
 	 */
-	private interface TypeHelper<T extends NativeType<T> & IntegerType<T>> extends Serializable {
+	protected interface TypeHelper<T extends NativeType<T> & IntegerType<T>> extends Serializable {
 		T getType();
 		Img<T> createImg(final long[] dimensions);
 		int clip(final int value);
 		boolean isOutsideThreshold(final int value);
 	}
 
-	private static class ByteHelper implements TypeHelper<UnsignedByteType> {
+	protected static class ByteHelper implements TypeHelper<UnsignedByteType> {
 		@Override
 		public UnsignedByteType getType() {
 			return new UnsignedByteType();
@@ -446,7 +349,7 @@ public class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & IntegerTyp
 		}
 	}
 
-	private static class ShortHelper implements TypeHelper<UnsignedShortType> {
+	protected static class ShortHelper implements TypeHelper<UnsignedShortType> {
 		@Override
 		public UnsignedShortType getType() {
 			return new UnsignedShortType();

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
@@ -77,14 +77,45 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 
 		@Option(name = "--factors",
 				usage = "If specified, generates a scale pyramid with given factors, e.g. 2,2,1")
-		public String factors;
+		protected String factors;
+
+		@Option(name = "--cutoff",
+				usage = "Cut this fraction of pixels on either side when computing the layer statistics (default: 0.03)")
+		protected double cutoff = 0.03;
 
 		protected Options() {
 			// Default constructor for subclasses
 		}
 
+		public double cutoff() {
+			return cutoff;
+		}
+
 		public String n5Path() {
 			return n5Path;
+		}
+
+		/**
+		 * Read and validate dataset attributes from N5.
+		 * Checks that output doesn't exist and input has valid attributes.
+		 *
+		 * @return the dataset attributes for the full scale input
+		 * @throws IOException if N5 access fails
+		 * @throws IllegalArgumentException if output exists or input has no attributes
+		 */
+		public DatasetAttributes readDatasetAttributes() throws IOException {
+			try (final N5Reader n5reader = N5Util.createN5Reader(n5Path)) {
+				if (n5reader.exists(n5DatasetOutput)) {
+					throw new IllegalArgumentException("Normalized data set already exists: " + n5DatasetOutput);
+				}
+
+				final String fullScaleInputDataset = n5DatasetInput + "/s0";
+				final DatasetAttributes attributes = n5reader.getDatasetAttributes(fullScaleInputDataset);
+				if (attributes == null) {
+					throw new IllegalArgumentException("no attributes found in " + n5Path + fullScaleInputDataset);
+				}
+				return attributes;
+			}
 		}
 
 		public String n5DatasetInput() {
@@ -252,13 +283,14 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 			this.max = max;
 		}
 
-		public static LayerStats from(final double[] pixels, final double cutoff) {
+		public static LayerStats from(final List<Double> pixelList, final double cutoff) {
+			// Convert to sorted array for rank statistics
+			final double[] pixels = pixelList.stream().mapToDouble(Double::doubleValue).sorted().toArray();
+
 			// Compute histogram clipping bounds
 			final int start = (int) Math.round(pixels.length * cutoff);
 			final int end = pixels.length - start;
 
-			// Sort the pixels to compute rank statistics
-			Arrays.sort(pixels);
 			final double median = pixels[pixels.length / 2];
 			final double min = pixels[start];
 			final double max = pixels[end - 1];


### PR DESCRIPTION
This PR strives to improve layer-wise contrast normalization by separating the functionality into two classes:
1. one for fib-sem, which does not need any masking
2. one for multi-sem, which needs some masking to account for the substrate breaking through at the bottom

Common functionality is contained in an abstract base class. Both methods were tested on a multi-sem stack with the following arguments.

```
# FIB-SEM
src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity
--n5Path /path/to.n5
--n5DatasetInput w60_s360/tissue
--n5DatasetOutput w60_s360/normalized_med_fibsem
--downsampleLevel 4
--shift MEDIAN
--scale NONE
--factors 2,2,1
```


```
# Multi-SEM
src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity
--n5Path /path/to.n5
--n5DatasetInput w60_s360/tissue
--n5DatasetOutput w60_s360/normalized_med_multisem
--downsampleLevel 4
--aggregation MEDIAN
--lowerThreshold 90
--upperThreshold 200
--factors 2,2,1
```