### PR TITLE
Optimize flattening

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FlattenTransform.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FlattenTransform.java
@@ -32,6 +32,13 @@ public class FlattenTransform<T extends RealType<T>> implements InvertibleRealTr
 	private final double min;
 	private final double norm;
 
+	// Cache for height field lookups: when consecutive calls share the same (x,y),
+	// skip the expensive bilinear interpolation of the height fields.
+	private double cachedX = Double.NaN;
+	private double cachedY = Double.NaN;
+	private double cachedMinHeight;
+	private double cachedMaxHeight;
+
 
 	public FlattenTransform(
 			final RealRandomAccessible<T> min,
@@ -98,6 +105,20 @@ public class FlattenTransform<T extends RealType<T>> implements InvertibleRealTr
 
 
 
+	private void updateHeightCache(final double x, final double y) {
+
+		if (x != cachedX || y != cachedY) {
+			minAccess.setPosition(x, 0);
+			minAccess.setPosition(y, 1);
+			maxAccess.setPosition(x, 0);
+			maxAccess.setPosition(y, 1);
+			cachedMinHeight = minAccess.get().getRealDouble();
+			cachedMaxHeight = maxAccess.get().getRealDouble();
+			cachedX = x;
+			cachedY = y;
+		}
+	}
+
 	@Override
 	public int numSourceDimensions() {
 
@@ -116,14 +137,10 @@ public class FlattenTransform<T extends RealType<T>> implements InvertibleRealTr
 		assert source.length <= target.length : "Target vector is too small.";
 
 		System.arraycopy(source, 0, target, 0, source.length);
+		updateHeightCache(source[0], source[1]);
+		final double scale = cachedMaxHeight - cachedMinHeight;
 
-		minAccess.setPosition(source);
-		maxAccess.setPosition(source);
-		final double minPosition = minAccess.get().getRealDouble();
-		final double maxPosition = maxAccess.get().getRealDouble();
-		final double scale = maxPosition - minPosition;
-
-		target[n] = (source[n] - minPosition) / scale * norm + min;
+		target[n] = (source[n] - cachedMinHeight) / scale * norm + min;
 	}
 
 	@Override
@@ -132,13 +149,10 @@ public class FlattenTransform<T extends RealType<T>> implements InvertibleRealTr
 		assert source.numDimensions() <= target.numDimensions() : "Target vector is too small.";
 
 		target.setPosition(source);
-		minAccess.setPosition(source);
-		maxAccess.setPosition(source);
-		final double minPosition = minAccess.get().getRealDouble();
-		final double maxPosition = maxAccess.get().getRealDouble();
-		final double scale = maxPosition - minPosition;
+		updateHeightCache(source.getDoublePosition(0), source.getDoublePosition(1));
+		final double scale = cachedMaxHeight - cachedMinHeight;
 
-		target.setPosition((source.getDoublePosition(n) - minPosition) / scale * norm + min, n);
+		target.setPosition((source.getDoublePosition(n) - cachedMinHeight) / scale * norm + min, n);
 	}
 
 	@Override
@@ -147,14 +161,10 @@ public class FlattenTransform<T extends RealType<T>> implements InvertibleRealTr
 		assert source.length <= target.length : "Target vector is too small.";
 
 		System.arraycopy(target, 0, source, 0, target.length);
+		updateHeightCache(target[0], target[1]);
+		final double scale = cachedMaxHeight - cachedMinHeight;
 
-		minAccess.setPosition(target);
-		maxAccess.setPosition(target);
-		final double minPosition = minAccess.get().getRealDouble();
-		final double maxPosition = maxAccess.get().getRealDouble();
-		final double scale = maxPosition - minPosition;
-
-		source[n] = (target[n] - min) / norm * scale + minPosition;
+		source[n] = (target[n] - min) / norm * scale + cachedMinHeight;
 	}
 
 	@Override
@@ -163,14 +173,10 @@ public class FlattenTransform<T extends RealType<T>> implements InvertibleRealTr
 		assert source.numDimensions() <= target.numDimensions() : "Target vector is too small.";
 
 		source.setPosition(target);
+		updateHeightCache(target.getDoublePosition(0), target.getDoublePosition(1));
+		final double scale = cachedMaxHeight - cachedMinHeight;
 
-		minAccess.setPosition(target);
-		maxAccess.setPosition(target);
-		final double minPosition = minAccess.get().getRealDouble();
-		final double maxPosition = maxAccess.get().getRealDouble();
-		final double scale = maxPosition - minPosition;
-
-		source.setPosition((target.getDoublePosition(n) - min) / norm * scale + minPosition, n);
+		source.setPosition((target.getDoublePosition(n) - min) / norm * scale + cachedMinHeight, n);
 	}
 
 	@Override

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FlattenTransform.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FlattenTransform.java
@@ -131,15 +131,17 @@ public class FlattenTransform<T extends RealType<T>> implements InvertibleRealTr
 		return n + 1;
 	}
 
+	@SuppressWarnings("ManualArrayCopy")
 	@Override
 	public void apply(final double[] source, final double[] target) {
 
 		assert source.length <= target.length : "Target vector is too small.";
 
-		System.arraycopy(source, 0, target, 0, source.length);
 		updateHeightCache(source[0], source[1]);
 		final double scale = cachedMaxHeight - cachedMinHeight;
 
+		for (int d = 0; d < n; d++)
+			target[d] = source[d];
 		target[n] = (source[n] - cachedMinHeight) / scale * norm + min;
 	}
 
@@ -148,22 +150,25 @@ public class FlattenTransform<T extends RealType<T>> implements InvertibleRealTr
 
 		assert source.numDimensions() <= target.numDimensions() : "Target vector is too small.";
 
-		target.setPosition(source);
 		updateHeightCache(source.getDoublePosition(0), source.getDoublePosition(1));
 		final double scale = cachedMaxHeight - cachedMinHeight;
 
+		for (int d = 0; d < n; d++)
+			target.setPosition(source.getDoublePosition(d), d);
 		target.setPosition((source.getDoublePosition(n) - cachedMinHeight) / scale * norm + min, n);
 	}
 
+	@SuppressWarnings("ManualArrayCopy")
 	@Override
 	public void applyInverse(final double[] source, final double[] target) {
 
 		assert source.length <= target.length : "Target vector is too small.";
 
-		System.arraycopy(target, 0, source, 0, target.length);
 		updateHeightCache(target[0], target[1]);
 		final double scale = cachedMaxHeight - cachedMinHeight;
 
+		for (int d = 0; d < n; d++)
+			source[d] = target[d];
 		source[n] = (target[n] - min) / norm * scale + cachedMinHeight;
 	}
 
@@ -172,10 +177,11 @@ public class FlattenTransform<T extends RealType<T>> implements InvertibleRealTr
 
 		assert source.numDimensions() <= target.numDimensions() : "Target vector is too small.";
 
-		source.setPosition(target);
 		updateHeightCache(target.getDoublePosition(0), target.getDoublePosition(1));
 		final double scale = cachedMaxHeight - cachedMinHeight;
 
+		for (int d = 0; d < n; d++)
+			source.setPosition(target.getDoublePosition(d), d);
 		source.setPosition((target.getDoublePosition(n) - min) / norm * scale + cachedMinHeight, n);
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkExportFlattenedVolume.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkExportFlattenedVolume.java
@@ -40,9 +40,9 @@ import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealRandomAccess;
 import net.imglib2.RealRandomAccessible;
 import net.imglib2.img.array.ArrayImgs;
-import net.imglib2.cache.img.CachedCellImg;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.multithreading.SimpleMultiThreading;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
@@ -314,13 +314,27 @@ public class SparkExportFlattenedVolume implements Callable<Void>, Serializable 
         // Only open writer if we're going to write
         final N5Writer n5Writer = DebugMode.INTERACTIVE.equals(debugMode) ? null : flatPathAndDataset.openWriter();
 
+        // Pre-allocate reusable state for direct column computation.
+        // Since output x,y are integers that pass through the FlattenTransform unchanged,
+        // the NLinear trilinear interpolation degenerates to linear interpolation in z only
+        // (6 of 8 neighbor weights are zero). We exploit this by pre-fetching each raw
+        // z-column into a local array and doing manual 1D linear interpolation, bypassing
+        // the entire imglib2 view chain and CachedCellImg per-access overhead.
+        final long rawMinZ = rawVolume.min(2);
+        final int rawZSize = (int) (rawVolume.max(2) - rawMinZ + 1);
+        final byte[] rawColumn = new byte[rawZSize];
+        final double transformMin = flatInfo.getMin();
+        final double invTransformNorm = 1.0 / (flatInfo.getMax() - flatInfo.getMin());
+        final RandomAccess<UnsignedByteType> rawAccess = rawVolume.randomAccess();
+        final RealRandomAccess<DoubleType> minHAccess = minFactors.realRandomAccess();
+        final RealRandomAccess<DoubleType> maxHAccess = maxFactors.realRandomAccess();
+
         while (gridBlockIterator.hasNext()) {
             final long[][] gridBlock = gridBlockIterator.next();
             System.out.println("Processing grid block: [" + gridBlock[2][0] + ", " + gridBlock[2][1] + "]");
 
-            final RandomAccessibleInterval<UnsignedByteType> sourceGridBlock = Views.offsetInterval(flattened, gridBlock[0], gridBlock[1]);
-
             if (DebugMode.INTERACTIVE.equals(debugMode)) {
+                final RandomAccessibleInterval<UnsignedByteType> sourceGridBlock = Views.offsetInterval(flattened, gridBlock[0], gridBlock[1]);
                 long[] min = new long[2];
                 long[] max = new long[min.length];
                 for (int d = 0; d < min.length; ++d) {
@@ -338,27 +352,57 @@ public class SparkExportFlattenedVolume implements Callable<Void>, Serializable 
                 return;
             }
 
-            // Copy from lazy view into concrete block using z-first iteration order.
-            // This maximizes cache hits in FlattenTransform's height field cache:
-            // for each (x,y) column, all z values reuse the same cached height field lookup.
             final RandomAccessibleInterval<UnsignedByteType> blockImg = ArrayImgs.unsignedBytes(gridBlock[1]);
-            final RandomAccess<UnsignedByteType> src = sourceGridBlock.randomAccess();
             final RandomAccess<UnsignedByteType> dst = blockImg.randomAccess();
 
             final int sizeX = (int) gridBlock[1][0];
             final int sizeY = (int) gridBlock[1][1];
             final int sizeZ = (int) gridBlock[1][2];
+            final long flatZBase = flatInfo.getMinWithPadding() + gridBlock[0][2];
 
             for (int y = 0; y < sizeY; y++) {
-                src.setPosition(y, 1);
+                final long rawY = rawVolume.min(1) + gridBlock[0][1] + y;
+                rawAccess.setPosition(rawY, 1);
+                minHAccess.setPosition((double) rawY, 1);
+                maxHAccess.setPosition((double) rawY, 1);
                 dst.setPosition(y, 1);
+
                 for (int x = 0; x < sizeX; x++) {
-                    src.setPosition(x, 0);
+                    final long rawX = rawVolume.min(0) + gridBlock[0][0] + x;
+                    rawAccess.setPosition(rawX, 0);
                     dst.setPosition(x, 0);
+
+                    // Height field lookup (once per column)
+                    minHAccess.setPosition((double) rawX, 0);
+                    maxHAccess.setPosition((double) rawX, 0);
+                    final double minH = minHAccess.get().getRealDouble();
+                    final double maxH = maxHAccess.get().getRealDouble();
+                    final double hScale = maxH - minH;
+
+                    // Pre-fetch raw z-column into local array
+                    for (int rz = 0; rz < rawZSize; rz++) {
+                        rawAccess.setPosition(rawMinZ + rz, 2);
+                        rawColumn[rz] = (byte) rawAccess.get().get();
+                    }
+
+                    // Linear z-interpolation from pre-fetched column
+                    final double zStep = hScale * invTransformNorm;
+                    double srcZ = (flatZBase - transformMin) * invTransformNorm * hScale + minH;
+
                     for (int z = 0; z < sizeZ; z++) {
-                        src.setPosition(z, 2);
+                        final int zFloor = (int) Math.floor(srcZ);
+                        final double frac = srcZ - zFloor;
+                        final int idx0 = zFloor - (int) rawMinZ;
+                        final int idx1 = idx0 + 1;
+
+                        final int v0 = (idx0 >= 0 && idx0 < rawZSize) ? (rawColumn[idx0] & 0xFF) : 0;
+                        final int v1 = (idx1 >= 0 && idx1 < rawZSize) ? (rawColumn[idx1] & 0xFF) : 0;
+                        final int value = (int) Math.round(v0 + frac * (v1 - v0));
+
                         dst.setPosition(z, 2);
-                        dst.get().set(src.get());
+                        dst.get().set(value);
+
+                        srcZ += zStep;
                     }
                 }
             }

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkExportFlattenedVolume.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkExportFlattenedVolume.java
@@ -21,6 +21,7 @@ import ij.ImageJ;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.concurrent.Callable;
 
 import org.apache.spark.SparkConf;
@@ -188,8 +189,7 @@ public class SparkExportFlattenedVolume implements Callable<Void>, Serializable 
         final N5PathAndDataset flatPathAndDataset = flatInfo.getFlatPathAndDataset();
 
         // Skip N5Writer creation in debug mode
-        if (DebugMode.INTERACTIVE.equals(debugMode))
-        {
+        if (DebugMode.INTERACTIVE.equals(debugMode)) {
             System.out.println("Debug mode: Skipping N5Writer creation for output");
         } else {
             try (N5Writer n5Writer = flatPathAndDataset.openWriter()) {
@@ -258,77 +258,86 @@ public class SparkExportFlattenedVolume implements Callable<Void>, Serializable 
             new ImageJ();
         }
 
-        // TODO: make sure no longer need to call N5Utils.open(setupRawReader, rawDataset); to prime attributes
-        rdd.foreach(
-                gridBlock -> {
-                    System.out.println("Processing grid block: [" + gridBlock[2][0] + ", " + gridBlock[2][1] + "]");
+        rdd.foreachPartition(
+                gridBlockIterator -> processPartition(gridBlockIterator, flatInfo, rawPathAndDataset, fieldPath, flatPathAndDataset, debugMode));
+    }
 
-                    final N5Reader n5RawReader = rawPathAndDataset.openReader();
-                    final N5Reader n5FieldReader = fieldPath.openReader();
+    private static void processPartition(final Iterator<long[][]> gridBlockIterator,
+                                         final FlatteningInfo flatInfo,
+                                         final N5PathAndDataset rawPathAndDataset,
+                                         final N5Path fieldPath,
+                                         final N5PathAndDataset flatPathAndDataset,
+                                         final DebugMode debugMode) {
 
-                    /* raw */
-                    final CachedCellImg<UnsignedByteType, ?> rawCellImg = N5Utils.open(n5RawReader, rawPathAndDataset.getDataset());
-                    final RandomAccessibleInterval<UnsignedByteType> rawVolume =
-                            flatInfo.isMultiSEMData() ? rawCellImg : Views.permute(rawCellImg, 1, 2);
+        if (!gridBlockIterator.hasNext())
+            return;
 
-                    System.out.println("Debug mode: rawVolume dimensions: " + net.imglib2.util.Util.printInterval(rawVolume));
+        // Open N5 connections once per partition
+        final N5Reader n5RawReader = rawPathAndDataset.openReader();
+        final N5Reader n5FieldReader = fieldPath.openReader();
 
-                    final RandomAccessibleInterval<FloatType> minField = N5Utils.open(n5FieldReader, flatInfo.getMinFieldDataset());
-                    final RandomAccessibleInterval<FloatType> maxField = N5Utils.open(n5FieldReader, flatInfo.getMaxFieldDataset());
+        // Open datasets (share cache across blocks in this partition)
+        final RandomAccessibleInterval<UnsignedByteType> rawData = N5Utils.open(n5RawReader, rawPathAndDataset.getDataset());
+        final RandomAccessibleInterval<UnsignedByteType> rawVolume =
+                flatInfo.isMultiSEMData() ? rawData : Views.permute(rawData, 1, 2);
 
-                    System.out.println("Debug mode: minField dimensions: " + net.imglib2.util.Util.printInterval(minField));
-                    System.out.println("Debug mode: maxField dimensions: " + net.imglib2.util.Util.printInterval(maxField));
+        final RandomAccessibleInterval<FloatType> minField = N5Utils.open(n5FieldReader, flatInfo.getMinFieldDataset());
+        final RandomAccessibleInterval<FloatType> maxField = N5Utils.open(n5FieldReader, flatInfo.getMaxFieldDataset());
 
-                    final RealRandomAccessible<DoubleType> minFactors = Transform.scaleAndShiftHeightFieldAndValues(minField, flatInfo.getFactors());
-                    final RealRandomAccessible<DoubleType> maxFactors = Transform.scaleAndShiftHeightFieldAndValues(maxField, flatInfo.getFactors());
+        System.out.println("Partition: rawVolume dimensions: " + net.imglib2.util.Util.printInterval(rawVolume));
+        System.out.println("Partition: minField dimensions: " + net.imglib2.util.Util.printInterval(minField));
+        System.out.println("Partition: maxField dimensions: " + net.imglib2.util.Util.printInterval(maxField));
 
-                    final FlattenTransform<DoubleType> flattenTransform = new FlattenTransform<>(minFactors,
-                                                                                                 maxFactors,
-                                                                                                 flatInfo.getMin(),
-                                                                                                 flatInfo.getMax());
+        // Set up transform
+        final RealRandomAccessible<DoubleType> minFactors = Transform.scaleAndShiftHeightFieldAndValues(minField, flatInfo.getFactors());
+        final RealRandomAccessible<DoubleType> maxFactors = Transform.scaleAndShiftHeightFieldAndValues(maxField, flatInfo.getFactors());
 
-                    System.out.println("Debug mode: Creating flattened transform with min=" + flatInfo.getMin() + ", max=" + flatInfo.getMax());
-                    System.out.println("Debug mode: Padding: minWithPadding=" + flatInfo.getMinWithPadding() + ", maxWithPadding=" + flatInfo.getMaxWithPadding());
+        final FlattenTransform<DoubleType> flattenTransform = new FlattenTransform<>(minFactors, maxFactors, flatInfo.getMin(), flatInfo.getMax());
 
-                    final RandomAccessibleInterval<UnsignedByteType> flattened =
-                            Views.zeroMin(
-                                    Transform.createTransformedInterval(
-                                            rawVolume,
-                                            new FinalInterval(
-                                                    new long[] {rawVolume.min(0), rawVolume.min(1), flatInfo.getMinWithPadding()},
-                                                    new long[] {rawVolume.max(0), rawVolume.max(1), flatInfo.getMaxWithPadding()}),
-                                            flattenTransform.inverse(),
-                                            new UnsignedByteType()));
+        System.out.println("Partition: FlattenTransform with min=" + flatInfo.getMin() + ", max=" + flatInfo.getMax() +
+                           ", minWithPadding=" + flatInfo.getMinWithPadding() + ", maxWithPadding=" + flatInfo.getMaxWithPadding());
 
-                    System.out.println("Debug mode: flattened dimensions: " + net.imglib2.util.Util.printInterval(flattened));
+        final RandomAccessibleInterval<UnsignedByteType> flattened =
+                Views.zeroMin(
+                        Transform.createTransformedInterval(
+                                rawVolume,
+                                new FinalInterval(
+                                        new long[] {rawVolume.min(0), rawVolume.min(1), flatInfo.getMinWithPadding()},
+                                        new long[] {rawVolume.max(0), rawVolume.max(1), flatInfo.getMaxWithPadding()}),
+                                flattenTransform.inverse(),
+                                new UnsignedByteType()));
 
-                    final RandomAccessibleInterval<UnsignedByteType> sourceGridBlock = Views.offsetInterval(flattened, gridBlock[0], gridBlock[1]);
+        System.out.println("Partition: flattened dimensions: " + net.imglib2.util.Util.printInterval(flattened));
 
-                    System.out.println("Debug mode: sourceGridBlock dimensions: " + net.imglib2.util.Util.printInterval(sourceGridBlock));
+        // Only open writer if we're going to write
+        final N5Writer n5Writer = DebugMode.INTERACTIVE.equals(debugMode) ? null : flatPathAndDataset.openWriter();
 
-                    // In debug mode, show results and stop without writing
-                    if (DebugMode.INTERACTIVE.equals(debugMode)) {
-                    	long[] min = new long[2];
-                    	long[] max = new long[ min.length ];
-                    	for ( int d = 0; d < min.length; ++d )
-                    	{
-                    		min[ d ] = gridBlock[0][d] / 2;
-                    		max[ d ] = min[ d ] + gridBlock[1][d]/2 - 1;
-                    	}
+        while (gridBlockIterator.hasNext()) {
+            final long[][] gridBlock = gridBlockIterator.next();
+            System.out.println("Processing grid block: [" + gridBlock[2][0] + ", " + gridBlock[2][1] + "]");
 
-                        System.out.println("Debug mode: Displaying results... for interval " + Arrays.toString( min ) + " >> " + Arrays.toString( max ));
-                        ImageJFunctions.show( Views.interval( minField, min, max ), "Min Height Field");
-                        ImageJFunctions.show( Views.interval( maxField, min, max ), "Max Height Field");
-                        ImageJFunctions.show(sourceGridBlock, "Flattened Block [" + gridBlock[2][0] + "," + gridBlock[2][1] + "]");
-                        System.out.println("Debug mode: Skipping N5 write operations");
-                        //noinspection deprecation
-                        SimpleMultiThreading.threadHaltUnClean();
-                        return;
-                    }
+            final RandomAccessibleInterval<UnsignedByteType> sourceGridBlock = Views.offsetInterval(flattened, gridBlock[0], gridBlock[1]);
 
-                    final N5Writer n5Writer = flatPathAndDataset.openWriter();
-                    N5Utils.saveBlock(sourceGridBlock, n5Writer, flatPathAndDataset.getDataset(), gridBlock[2]);
-                });
+            if (DebugMode.INTERACTIVE.equals(debugMode)) {
+                long[] min = new long[2];
+                long[] max = new long[min.length];
+                for (int d = 0; d < min.length; ++d) {
+                    min[d] = gridBlock[0][d] / 2;
+                    max[d] = min[d] + gridBlock[1][d] / 2 - 1;
+                }
+
+                System.out.println("Debug mode: Displaying results... for interval " + Arrays.toString(min) + " >> " + Arrays.toString(max));
+                ImageJFunctions.show(Views.interval(minField, min, max), "Min Height Field");
+                ImageJFunctions.show(Views.interval(maxField, min, max), "Max Height Field");
+                ImageJFunctions.show(sourceGridBlock, "Flattened Block [" + gridBlock[2][0] + "," + gridBlock[2][1] + "]");
+                System.out.println("Debug mode: Skipping N5 write operations");
+                //noinspection deprecation
+                SimpleMultiThreading.threadHaltUnClean();
+                return;
+            }
+
+            N5Utils.saveBlock(sourceGridBlock, n5Writer, flatPathAndDataset.getDataset(), gridBlock[2]);
+        }
     }
 
     public static void main(final String... args) {

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkExportFlattenedVolume.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkExportFlattenedVolume.java
@@ -314,21 +314,6 @@ public class SparkExportFlattenedVolume implements Callable<Void>, Serializable 
         // Only open writer if we're going to write
         final N5Writer n5Writer = DebugMode.INTERACTIVE.equals(debugMode) ? null : flatPathAndDataset.openWriter();
 
-        // Pre-allocate reusable state for direct column computation.
-        // Since output x,y are integers that pass through the FlattenTransform unchanged,
-        // the NLinear trilinear interpolation degenerates to linear interpolation in z only
-        // (6 of 8 neighbor weights are zero). We exploit this by pre-fetching each raw
-        // z-column into a local array and doing manual 1D linear interpolation, bypassing
-        // the entire imglib2 view chain and CachedCellImg per-access overhead.
-        final long rawMinZ = rawVolume.min(2);
-        final int rawZSize = (int) (rawVolume.max(2) - rawMinZ + 1);
-        final byte[] rawColumn = new byte[rawZSize];
-        final double transformMin = flatInfo.getMin();
-        final double invTransformNorm = 1.0 / (flatInfo.getMax() - flatInfo.getMin());
-        final RandomAccess<UnsignedByteType> rawAccess = rawVolume.randomAccess();
-        final RealRandomAccess<DoubleType> minHAccess = minFactors.realRandomAccess();
-        final RealRandomAccess<DoubleType> maxHAccess = maxFactors.realRandomAccess();
-
         while (gridBlockIterator.hasNext()) {
             final long[][] gridBlock = gridBlockIterator.next();
             System.out.println("Processing grid block: [" + gridBlock[2][0] + ", " + gridBlock[2][1] + "]");
@@ -352,63 +337,108 @@ public class SparkExportFlattenedVolume implements Callable<Void>, Serializable 
                 return;
             }
 
-            final RandomAccessibleInterval<UnsignedByteType> blockImg = ArrayImgs.unsignedBytes(gridBlock[1]);
-            final RandomAccess<UnsignedByteType> dst = blockImg.randomAccess();
-
-            final int sizeX = (int) gridBlock[1][0];
-            final int sizeY = (int) gridBlock[1][1];
-            final int sizeZ = (int) gridBlock[1][2];
-            final long flatZBase = flatInfo.getMinWithPadding() + gridBlock[0][2];
-
-            for (int y = 0; y < sizeY; y++) {
-                final long rawY = rawVolume.min(1) + gridBlock[0][1] + y;
-                rawAccess.setPosition(rawY, 1);
-                minHAccess.setPosition((double) rawY, 1);
-                maxHAccess.setPosition((double) rawY, 1);
-                dst.setPosition(y, 1);
-
-                for (int x = 0; x < sizeX; x++) {
-                    final long rawX = rawVolume.min(0) + gridBlock[0][0] + x;
-                    rawAccess.setPosition(rawX, 0);
-                    dst.setPosition(x, 0);
-
-                    // Height field lookup (once per column)
-                    minHAccess.setPosition((double) rawX, 0);
-                    maxHAccess.setPosition((double) rawX, 0);
-                    final double minH = minHAccess.get().getRealDouble();
-                    final double maxH = maxHAccess.get().getRealDouble();
-                    final double hScale = maxH - minH;
-
-                    // Pre-fetch raw z-column into local array
-                    for (int rz = 0; rz < rawZSize; rz++) {
-                        rawAccess.setPosition(rawMinZ + rz, 2);
-                        rawColumn[rz] = (byte) rawAccess.get().get();
-                    }
-
-                    // Linear z-interpolation from pre-fetched column
-                    final double zStep = hScale * invTransformNorm;
-                    double srcZ = (flatZBase - transformMin) * invTransformNorm * hScale + minH;
-
-                    for (int z = 0; z < sizeZ; z++) {
-                        final int zFloor = (int) Math.floor(srcZ);
-                        final double frac = srcZ - zFloor;
-                        final int idx0 = zFloor - (int) rawMinZ;
-                        final int idx1 = idx0 + 1;
-
-                        final int v0 = (idx0 >= 0 && idx0 < rawZSize) ? (rawColumn[idx0] & 0xFF) : 0;
-                        final int v1 = (idx1 >= 0 && idx1 < rawZSize) ? (rawColumn[idx1] & 0xFF) : 0;
-                        final int value = (int) Math.round(v0 + frac * (v1 - v0));
-
-                        dst.setPosition(z, 2);
-                        dst.get().set(value);
-
-                        srcZ += zStep;
-                    }
-                }
-            }
+            final RandomAccessibleInterval<UnsignedByteType> blockImg = computeFlattenedBlock(
+                    rawVolume, minFactors, maxFactors,
+                    flatInfo.getMin(), flatInfo.getMax(), flatInfo.getMinWithPadding(),
+                    gridBlock[0], gridBlock[1]);
 
             N5Utils.saveBlock(blockImg, n5Writer, flatPathAndDataset.getDataset(), gridBlock[2]);
         }
+    }
+
+    /**
+     * Computes a single flattened output block by direct column-wise processing.
+     * <p>
+     * Since output x,y are integer positions that pass through the flatten transform unchanged,
+     * the trilinear interpolation degenerates to linear interpolation in z only. This method
+     * exploits that by pre-fetching each raw z-column and doing manual 1D linear interpolation,
+     * bypassing the imglib2 view chain and CachedCellImg per-access overhead.
+     *
+     * @param rawVolume       the raw 3D volume to sample from
+     * @param minHeightField  the scaled min surface height field
+     * @param maxHeightField  the scaled max surface height field
+     * @param flatMin         minimum surface position in raw z-coordinates
+     * @param flatMax         maximum surface position in raw z-coordinates
+     * @param minWithPadding  padded min z in flat output space
+     * @param blockOffset     block offset in the output (0-based) coordinate system
+     * @param blockSize       block dimensions
+     * @return a concrete ArrayImg containing the flattened block
+     */
+    public static RandomAccessibleInterval<UnsignedByteType> computeFlattenedBlock(
+            final RandomAccessibleInterval<UnsignedByteType> rawVolume,
+            final RealRandomAccessible<DoubleType> minHeightField,
+            final RealRandomAccessible<DoubleType> maxHeightField,
+            final double flatMin,
+            final double flatMax,
+            final int minWithPadding,
+            final long[] blockOffset,
+            final long[] blockSize) {
+
+        final long rawMinZ = rawVolume.min(2);
+        final int rawZSize = (int) (rawVolume.max(2) - rawMinZ + 1);
+        final byte[] rawColumn = new byte[rawZSize];
+        final double invNorm = 1.0 / (flatMax - flatMin);
+
+        final RandomAccess<UnsignedByteType> rawAccess = rawVolume.randomAccess();
+        final RealRandomAccess<DoubleType> minHAccess = minHeightField.realRandomAccess();
+        final RealRandomAccess<DoubleType> maxHAccess = maxHeightField.realRandomAccess();
+
+        final RandomAccessibleInterval<UnsignedByteType> blockImg = ArrayImgs.unsignedBytes(blockSize);
+        final RandomAccess<UnsignedByteType> dst = blockImg.randomAccess();
+
+        final int sizeX = (int) blockSize[0];
+        final int sizeY = (int) blockSize[1];
+        final int sizeZ = (int) blockSize[2];
+        final long flatZBase = minWithPadding + blockOffset[2];
+
+        for (int y = 0; y < sizeY; y++) {
+            final long rawY = rawVolume.min(1) + blockOffset[1] + y;
+            rawAccess.setPosition(rawY, 1);
+            minHAccess.setPosition((double) rawY, 1);
+            maxHAccess.setPosition((double) rawY, 1);
+            dst.setPosition(y, 1);
+
+            for (int x = 0; x < sizeX; x++) {
+                final long rawX = rawVolume.min(0) + blockOffset[0] + x;
+                rawAccess.setPosition(rawX, 0);
+                dst.setPosition(x, 0);
+
+                // Height field lookup (once per column)
+                minHAccess.setPosition((double) rawX, 0);
+                maxHAccess.setPosition((double) rawX, 0);
+                final double minH = minHAccess.get().getRealDouble();
+                final double maxH = maxHAccess.get().getRealDouble();
+                final double hScale = maxH - minH;
+
+                // Pre-fetch raw z-column into local array
+                for (int rz = 0; rz < rawZSize; rz++) {
+                    rawAccess.setPosition(rawMinZ + rz, 2);
+                    rawColumn[rz] = (byte) rawAccess.get().get();
+                }
+
+                // Linear z-interpolation from pre-fetched column
+                final double zStep = hScale * invNorm;
+                double srcZ = (flatZBase - flatMin) * invNorm * hScale + minH;
+
+                for (int z = 0; z < sizeZ; z++) {
+                    final int zFloor = (int) Math.floor(srcZ);
+                    final double frac = srcZ - zFloor;
+                    final int idx0 = zFloor - (int) rawMinZ;
+                    final int idx1 = idx0 + 1;
+
+                    final int v0 = (idx0 >= 0 && idx0 < rawZSize) ? (rawColumn[idx0] & 0xFF) : 0;
+                    final int v1 = (idx1 >= 0 && idx1 < rawZSize) ? (rawColumn[idx1] & 0xFF) : 0;
+                    final int value = (int) Math.round(v0 + frac * (v1 - v0));
+
+                    dst.setPosition(z, 2);
+                    dst.get().set(value);
+
+                    srcZ += zStep;
+                }
+            }
+        }
+
+        return blockImg;
     }
 
     public static void main(final String... args) {

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkExportFlattenedVolume.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkExportFlattenedVolume.java
@@ -38,8 +38,10 @@ import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 
 import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.RealRandomAccessible;
+import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.cache.img.CachedCellImg;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.multithreading.SimpleMultiThreading;
@@ -336,7 +338,32 @@ public class SparkExportFlattenedVolume implements Callable<Void>, Serializable 
                 return;
             }
 
-            N5Utils.saveBlock(sourceGridBlock, n5Writer, flatPathAndDataset.getDataset(), gridBlock[2]);
+            // Copy from lazy view into concrete block using z-first iteration order.
+            // This maximizes cache hits in FlattenTransform's height field cache:
+            // for each (x,y) column, all z values reuse the same cached height field lookup.
+            final RandomAccessibleInterval<UnsignedByteType> blockImg = ArrayImgs.unsignedBytes(gridBlock[1]);
+            final RandomAccess<UnsignedByteType> src = sourceGridBlock.randomAccess();
+            final RandomAccess<UnsignedByteType> dst = blockImg.randomAccess();
+
+            final int sizeX = (int) gridBlock[1][0];
+            final int sizeY = (int) gridBlock[1][1];
+            final int sizeZ = (int) gridBlock[1][2];
+
+            for (int y = 0; y < sizeY; y++) {
+                src.setPosition(y, 1);
+                dst.setPosition(y, 1);
+                for (int x = 0; x < sizeX; x++) {
+                    src.setPosition(x, 0);
+                    dst.setPosition(x, 0);
+                    for (int z = 0; z < sizeZ; z++) {
+                        src.setPosition(z, 2);
+                        dst.setPosition(z, 2);
+                        dst.get().set(src.get());
+                    }
+                }
+            }
+
+            N5Utils.saveBlock(blockImg, n5Writer, flatPathAndDataset.getDataset(), gridBlock[2]);
         }
     }
 

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkGenerateFaceScaleSpace.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkGenerateFaceScaleSpace.java
@@ -61,7 +61,6 @@ import net.imglib2.view.Views;
  */
 public class SparkGenerateFaceScaleSpace {
 
-	@SuppressWarnings("serial")
 	public static class Options extends AbstractOptions implements Serializable {
 
 		@Option(name = "--n5Path", required = true, usage = "N5 path, e.g. /nrs/flyem/data/tmp/Z0115-22.n5")
@@ -91,7 +90,7 @@ public class SparkGenerateFaceScaleSpace {
 		@Option(name = "--invert", usage = "MultiSem datasets might be inverted")
 		private boolean invert = false;
 
-		@Option(name = "--normalizeContrast", usage = "Perform contast normalization on the input data")
+		@Option(name = "--normalizeContrast", usage = "Perform contrast normalization on the input data")
 		private boolean normalizeContrast = false;
 
 		public Options(final String[] args) {
@@ -191,13 +190,6 @@ public class SparkGenerateFaceScaleSpace {
 		}
 	}
 
-	static public double sigmaDiff(final double sourceSigma, final double targetSigma, final double scale) {
-
-		final double s = targetSigma / scale;
-		final double v = Math.max(0, s * s - sourceSigma * sourceSigma);
-		return Math.sqrt(v);
-	}
-
 	static public long[] downsample(
 			final JavaSparkContext sc,
 			final String n5Path,
@@ -216,7 +208,8 @@ public class SparkGenerateFaceScaleSpace {
 		final DataType inType = attributes.getDataType();
 
 		final int sampleStepSize = net.imglib2.util.Util.pow(2, scaleIndex);
-		final double sigma = sigmaDiff(0.5, 0.5, 1.0 / sampleStepSize);
+
+		final double sigma = GenerateFaceScaleSpace.sigmaDiff(0.5, 0.5, 1.0 / sampleStepSize);
 		final double[] sigmas = new double[] { sigma, sigma, sigma };
 
 		final long[] outDimensions = Arrays.stream(size).map(x -> Math.abs(x) / sampleStepSize).toArray();
@@ -372,7 +365,7 @@ public class SparkGenerateFaceScaleSpace {
 		}
 	}
 
-	public static final void extractFace(
+	public static void extractFace(
 			final JavaSparkContext sc,
 			final String n5Path,
 			final String inDatasetName,
@@ -382,7 +375,7 @@ public class SparkGenerateFaceScaleSpace {
 			final int[] outBlockSize,
 			final boolean invert,
 			final boolean normalizeContrast,
-			final int scaleIndex ) throws IOException {
+			final int scaleIndex) {
 
 		final N5Writer n5 = N5Util.createN5Writer(n5Path);
 
@@ -505,8 +498,8 @@ public class SparkGenerateFaceScaleSpace {
 					1,
 					scaleSpaceDataSetName,
 					attributes.getBlockSize(),
-					scaleIndex == 1 ? options.invert : false, // only when downsampling to s1 we need filtering
-					scaleIndex == 1 ? options.normalizeContrast : false ); // only when downsampling to s1 we need filtering
+                    scaleIndex == 1 && options.invert, // only when downsampling to s1 we need filtering
+                    scaleIndex == 1 && options.normalizeContrast); // only when downsampling to s1 we need filtering
 
 			sourceDatasetName = scaleSpaceDataSetName;
 			Arrays.fill(min, 0);

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkGenerateFaceScaleSpace.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkGenerateFaceScaleSpace.java
@@ -235,77 +235,143 @@ public class SparkGenerateFaceScaleSpace {
 					final N5Writer n5Writer = N5Util.createN5Writer(n5Path);
 
 					while (blocks.hasNext()) {
-						final long[][] gridBlock = blocks.next();
-						System.out.println(Arrays.deepToString(gridBlock));
-
-						@SuppressWarnings("unchecked")
-						final RandomAccessibleInterval<RealType<?>> source;
-
-						// only s0 is UnsignedByteType, the rest is FloatType and already inverted and normalized (if asked for)
-						if ( invert || normalizeContrast )
-						{
-							// we choose a non-power-of-2 blocksize on purpose since the grids do not align here typically
-							// a size of 1 in z makes sense since it is a 2d filter and we do not want to do cllcn and not need it
-							final int[] blockSize_cllcn = new int[] { (int)gridBlock[1][0] + 1, (int)gridBlock[1][1] + 1, 1 };
-
-							source = (RandomAccessibleInterval<RealType<?>>)(Object) filter(
-									(RandomAccessibleInterval<UnsignedByteType>)N5Utils.open(n5Writer, inDatasetName),
-									invert,
-									normalizeContrast,
-									0, // here scaleIndex is the result of the downsampling, not the input
-									blockSize_cllcn );
-						}
-						else
-						{
-							source = (RandomAccessibleInterval)N5Utils.open(n5Writer, inDatasetName);
-						}
-
-						@SuppressWarnings({ "rawtypes", "unchecked" })
-						final RandomAccessibleInterval<FloatType> floatSource =
-								inType == DataType.FLOAT32 ? (RandomAccessibleInterval)source : Converters.convert(
-										source,
-										(a, b) -> b.set(a.getRealFloat()),
-										new FloatType());
-
-						final long[] absMin = new long[min.length];
-						final long[] absSize = new long[size.length];
-						for (int d = 0; d < min.length; ++d) {
-							if (size[d] < 0) {
-								absMin[d] = min[d] + size[d];
-								absSize[d] = -size[d];
-							}
-							else {
-								absMin[d] = min[d];
-								absSize[d] = size[d];
-							}
-						}
-
-						//System.out.println("abs min: " + Arrays.toString(absMin) + " size " + Arrays.toString(absSize));
-
-						IntervalView<FloatType> roi = Views.offsetInterval(floatSource, absMin, absSize);
-						for (int d = 0; d < roi.numDimensions(); ++d)
-							if (size[d] < 0)
-								roi = Views.invertAxis(roi, d);
-
-						final RandomAccessibleInterval<FloatType> zeroMin = Views.zeroMin(roi);
-
-						final SimpleGaussRA<FloatType> gauss = new SimpleGaussRA<>(sigmas);
-						final RandomAccessibleInterval<FloatType> filtered = Lazy.process(
-								Views.extendMirrorSingle(zeroMin),
-								zeroMin,
-								outBlockSize,// new int[] { 33, 33, 7 }, // small blocksize to make sure we do not compute things for nothing, specifically if normalize constrast is on
-								new FloatType(),
-								AccessFlags.setOf(),
-								gauss);
-						final SubsampleIntervalView<FloatType> subsampled = Views.subsample(filtered, sampleStepSize);
-
-						final RandomAccessibleInterval<FloatType> sourceGridBlock = Views.offsetInterval(subsampled, gridBlock[0], gridBlock[1]);
-
-						N5Utils.saveBlock(sourceGridBlock, n5Writer, outDatasetName, gridBlock[2]);
+						downsampleBlock(blocks.next(),
+										n5Writer,
+										inDatasetName,
+										invert,
+										normalizeContrast,
+										inType,
+										min,
+										size,
+										sigmas,
+										outBlockSize,
+										sampleStepSize,
+										outDatasetName);
 					}
 				});
 
 		return outDimensions;
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private static void downsampleBlock(
+			final long[][] gridBlock,
+			final N5Writer n5Writer,
+			final String inDatasetName,
+			final boolean invert,
+			final boolean normalizeContrast,
+			final DataType inType,
+			final long[] min,
+			final long[] size,
+			final double[] sigmas,
+			final int[] outBlockSize,
+			final int sampleStepSize,
+			final String outDatasetName) throws IOException {
+
+		System.out.println(Arrays.deepToString(gridBlock));
+
+		final RandomAccessibleInterval<RealType<?>> source;
+
+		// only s0 is UnsignedByteType, the rest is FloatType and already inverted and normalized (if asked for)
+		if (invert || normalizeContrast) {
+			// we choose a non-power-of-2 blocksize on purpose since the grids do not align here typically
+			// a size of 1 in z makes sense since it is a 2d filter and we do not want to do cllcn and not need it
+			final int[] blockSize_cllcn = new int[] { (int)gridBlock[1][0] + 1, (int)gridBlock[1][1] + 1, 1 };
+
+			source = (RandomAccessibleInterval<RealType<?>>)(Object) filter(
+					(RandomAccessibleInterval<UnsignedByteType>)N5Utils.open(n5Writer, inDatasetName),
+					invert,
+					normalizeContrast,
+					0, // here scaleIndex is the result of the downsampling, not the input
+					blockSize_cllcn );
+		} else {
+			source = (RandomAccessibleInterval)N5Utils.open(n5Writer, inDatasetName);
+		}
+
+		final RandomAccessibleInterval<FloatType> floatSource =
+				inType == DataType.FLOAT32 ? (RandomAccessibleInterval)source : Converters.convert(
+						source,
+						(a, b) -> b.set(a.getRealFloat()),
+						new FloatType());
+
+		final long[] absMin = new long[min.length];
+		final long[] absSize = new long[size.length];
+		for (int d = 0; d < min.length; ++d) {
+			if (size[d] < 0) {
+				absMin[d] = min[d] + size[d];
+				absSize[d] = -size[d];
+			} else {
+				absMin[d] = min[d];
+				absSize[d] = size[d];
+			}
+		}
+
+		IntervalView<FloatType> roi = Views.offsetInterval(floatSource, absMin, absSize);
+		for (int d = 0; d < roi.numDimensions(); ++d)
+			if (size[d] < 0)
+				roi = Views.invertAxis(roi, d);
+
+		final RandomAccessibleInterval<FloatType> zeroMin = Views.zeroMin(roi);
+
+		final SimpleGaussRA<FloatType> gauss = new SimpleGaussRA<>(sigmas);
+		final RandomAccessibleInterval<FloatType> filtered = Lazy.process(
+				Views.extendMirrorSingle(zeroMin),
+				zeroMin,
+				outBlockSize,
+				new FloatType(),
+				AccessFlags.setOf(),
+				gauss);
+		final SubsampleIntervalView<FloatType> subsampled = Views.subsample(filtered, sampleStepSize);
+
+		final RandomAccessibleInterval<FloatType> sourceGridBlock = Views.offsetInterval(subsampled, gridBlock[0], gridBlock[1]);
+
+		N5Utils.saveBlock(sourceGridBlock, n5Writer, outDatasetName, gridBlock[2]);
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private static void extractFaceBlock(
+			final long[][] gridBlock,
+			final N5Writer n5Writer,
+			final String inDatasetName,
+			final boolean invert,
+			final boolean normalizeContrast,
+			final int scaleIndex,
+			final DataType inType,
+			final long[] absMin,
+			final long[] absSize,
+			final long[] size,
+			final String outDatasetName) throws IOException {
+
+		System.out.println(Arrays.deepToString(gridBlock));
+
+		final RandomAccessibleInterval<RealType<?>> source;
+
+		// only s0 is UnsignedByteType, the rest is FloatType and already inverted and normalized (if asked for)
+		if (invert || normalizeContrast) {
+			source = (RandomAccessibleInterval<RealType<?>>)(Object) filter(
+					(RandomAccessibleInterval<UnsignedByteType>)N5Utils.open(n5Writer, inDatasetName),
+					invert,
+					normalizeContrast,
+					scaleIndex );
+		} else {
+			source = (RandomAccessibleInterval)N5Utils.open(n5Writer, inDatasetName);
+		}
+
+		final RandomAccessibleInterval<FloatType> floatSource =
+				inType == DataType.FLOAT32 ? (RandomAccessibleInterval)source : Converters.convert(
+						source,
+						(a, b) -> b.set(a.getRealFloat()),
+						new FloatType());
+
+		IntervalView<FloatType> roi = Views.offsetInterval(Views.extendZero(floatSource), absMin, absSize);
+		for (int d = 0; d < roi.numDimensions(); ++d)
+			if (size[d] < 0)
+				roi = Views.invertAxis(roi, d);
+
+		final IntervalView<FloatType> zeroMin = Views.zeroMin(roi);
+		final IntervalView<FloatType> face = Views.hyperSlice(zeroMin, 2, 0);
+		final RandomAccessibleInterval<FloatType> sourceGridBlock = Views.offsetInterval(face, gridBlock[0], gridBlock[1]);
+		N5Utils.saveBlock(sourceGridBlock, n5Writer, outDatasetName, gridBlock[2]);
 	}
 
 	protected static RandomAccessibleInterval<UnsignedByteType> filter(
@@ -419,41 +485,17 @@ public class SparkGenerateFaceScaleSpace {
 					final N5Writer n5Writer = N5Util.createN5Writer(n5Path);
 
 					while (blocks.hasNext()) {
-						final long[][] gridBlock = blocks.next();
-						System.out.println(Arrays.deepToString(gridBlock));
-
-						final RandomAccessibleInterval<RealType<?>> source;
-
-						// only s0 is UnsignedByteType, the rest is FloatType and already inverted and normalized (if asked for)
-						if ( invert || normalizeContrast )
-						{
-							source = (RandomAccessibleInterval<RealType<?>>)(Object) filter(
-									(RandomAccessibleInterval<UnsignedByteType>)N5Utils.open(n5Writer, inDatasetName),
-									invert,
-									normalizeContrast,
-									scaleIndex );
-						}
-						else
-						{
-							source = (RandomAccessibleInterval)N5Utils.open(n5Writer, inDatasetName);
-						}
-
-						@SuppressWarnings({ "rawtypes", "unchecked" })
-						final RandomAccessibleInterval<FloatType> floatSource =
-								inType == DataType.FLOAT32 ? (RandomAccessibleInterval)source : Converters.convert(
-										source,
-										(a, b) -> b.set(a.getRealFloat()),
-										new FloatType());
-
-						IntervalView<FloatType> roi = Views.offsetInterval(Views.extendZero( floatSource ), absMin, absSize);
-						for (int d = 0; d < roi.numDimensions(); ++d)
-							if (size[d] < 0)
-								roi = Views.invertAxis(roi, d);
-
-						final IntervalView<FloatType> zeroMin = Views.zeroMin(roi);
-						final IntervalView<FloatType> face = Views.hyperSlice(zeroMin, 2, 0);
-						final RandomAccessibleInterval<FloatType> sourceGridBlock = Views.offsetInterval(face, gridBlock[0], gridBlock[1]);
-						N5Utils.saveBlock(sourceGridBlock, n5Writer, outDatasetName, gridBlock[2]);
+						extractFaceBlock(blocks.next(),
+										 n5Writer,
+										 inDatasetName,
+										 invert,
+										 normalizeContrast,
+										 scaleIndex,
+										 inType,
+										 absMin,
+										 absSize,
+										 size,
+										 outDatasetName);
 					}
 				});
 	}

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkGenerateFaceScaleSpace.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkGenerateFaceScaleSpace.java
@@ -230,75 +230,79 @@ public class SparkGenerateFaceScaleSpace {
 								outDimensions,
 								outBlockSize));
 
-		rdd.foreach(
-				gridBlock -> {
-					System.out.println(Arrays.deepToString(gridBlock));
-
+		rdd.foreachPartition(
+				blocks -> {
 					final N5Writer n5Writer = N5Util.createN5Writer(n5Path);
-					@SuppressWarnings("unchecked")
-					final RandomAccessibleInterval<RealType<?>> source;
 
-					// only s0 is UnsignedByteType, the rest is FloatType and already inverted and normalized (if asked for)
-					if ( invert || normalizeContrast )
-					{
-						// we choose a non-power-of-2 blocksize on purpose since the grids do not align here typically
-						// a size of 1 in z makes sense since it is a 2d filter and we do not want to do cllcn and not need it
-						final int[] blockSize_cllcn = new int[] { (int)gridBlock[1][0] + 1, (int)gridBlock[1][1] + 1, 1 };
+					while (blocks.hasNext()) {
+						final long[][] gridBlock = blocks.next();
+						System.out.println(Arrays.deepToString(gridBlock));
 
-						source = (RandomAccessibleInterval<RealType<?>>)(Object) filter(
-								(RandomAccessibleInterval<UnsignedByteType>)N5Utils.open(n5Writer, inDatasetName),
-								invert,
-								normalizeContrast,
-								0, // here scaleIndex is the result of the downsampling, not the input
-								blockSize_cllcn );
-					}
-					else
-					{
-						source = (RandomAccessibleInterval)N5Utils.open(n5Writer, inDatasetName);
-					}
+						@SuppressWarnings("unchecked")
+						final RandomAccessibleInterval<RealType<?>> source;
 
-					@SuppressWarnings({ "rawtypes", "unchecked" })
-					final RandomAccessibleInterval<FloatType> floatSource =
-							inType == DataType.FLOAT32 ? (RandomAccessibleInterval)source : Converters.convert(
-									source,
-									(a, b) -> b.set(a.getRealFloat()),
-									new FloatType());
+						// only s0 is UnsignedByteType, the rest is FloatType and already inverted and normalized (if asked for)
+						if ( invert || normalizeContrast )
+						{
+							// we choose a non-power-of-2 blocksize on purpose since the grids do not align here typically
+							// a size of 1 in z makes sense since it is a 2d filter and we do not want to do cllcn and not need it
+							final int[] blockSize_cllcn = new int[] { (int)gridBlock[1][0] + 1, (int)gridBlock[1][1] + 1, 1 };
 
-					final long[] absMin = new long[min.length];
-					final long[] absSize = new long[size.length];
-					for (int d = 0; d < min.length; ++d) {
-						if (size[d] < 0) {
-							absMin[d] = min[d] + size[d];
-							absSize[d] = -size[d];
+							source = (RandomAccessibleInterval<RealType<?>>)(Object) filter(
+									(RandomAccessibleInterval<UnsignedByteType>)N5Utils.open(n5Writer, inDatasetName),
+									invert,
+									normalizeContrast,
+									0, // here scaleIndex is the result of the downsampling, not the input
+									blockSize_cllcn );
 						}
-						else {
-							absMin[d] = min[d];
-							absSize[d] = size[d];
+						else
+						{
+							source = (RandomAccessibleInterval)N5Utils.open(n5Writer, inDatasetName);
 						}
+
+						@SuppressWarnings({ "rawtypes", "unchecked" })
+						final RandomAccessibleInterval<FloatType> floatSource =
+								inType == DataType.FLOAT32 ? (RandomAccessibleInterval)source : Converters.convert(
+										source,
+										(a, b) -> b.set(a.getRealFloat()),
+										new FloatType());
+
+						final long[] absMin = new long[min.length];
+						final long[] absSize = new long[size.length];
+						for (int d = 0; d < min.length; ++d) {
+							if (size[d] < 0) {
+								absMin[d] = min[d] + size[d];
+								absSize[d] = -size[d];
+							}
+							else {
+								absMin[d] = min[d];
+								absSize[d] = size[d];
+							}
+						}
+
+						//System.out.println("abs min: " + Arrays.toString(absMin) + " size " + Arrays.toString(absSize));
+
+						IntervalView<FloatType> roi = Views.offsetInterval(floatSource, absMin, absSize);
+						for (int d = 0; d < roi.numDimensions(); ++d)
+							if (size[d] < 0)
+								roi = Views.invertAxis(roi, d);
+
+						final RandomAccessibleInterval<FloatType> zeroMin = Views.zeroMin(roi);
+
+						final SimpleGaussRA<FloatType> gauss = new SimpleGaussRA<>(sigmas);
+						final RandomAccessibleInterval<FloatType> filtered = Lazy.process(
+								Views.extendMirrorSingle(zeroMin),
+								zeroMin,
+								outBlockSize,// new int[] { 33, 33, 7 }, // small blocksize to make sure we do not compute things for nothing, specifically if normalize constrast is on
+								new FloatType(),
+								AccessFlags.setOf(),
+								gauss);
+						final SubsampleIntervalView<FloatType> subsampled = Views.subsample(filtered, sampleStepSize);
+
+						final RandomAccessibleInterval<FloatType> sourceGridBlock = Views.offsetInterval(subsampled, gridBlock[0], gridBlock[1]);
+
+						N5Utils.saveBlock(sourceGridBlock, n5Writer, outDatasetName, gridBlock[2]);
 					}
-
-					//System.out.println("abs min: " + Arrays.toString(absMin) + " size " + Arrays.toString(absSize));
-
-					IntervalView<FloatType> roi = Views.offsetInterval(floatSource, absMin, absSize);
-					for (int d = 0; d < roi.numDimensions(); ++d)
-						if (size[d] < 0)
-							roi = Views.invertAxis(roi, d);
-
-					final RandomAccessibleInterval<FloatType> zeroMin = Views.zeroMin(roi);
-
-					final SimpleGaussRA<FloatType> gauss = new SimpleGaussRA<>(sigmas);
-					final RandomAccessibleInterval<FloatType> filtered = Lazy.process(
-							Views.extendMirrorSingle(zeroMin),
-							zeroMin,
-							outBlockSize,// new int[] { 33, 33, 7 }, // small blocksize to make sure we do not compute things for nothing, specifically if normalize constrast is on
-							new FloatType(),
-							AccessFlags.setOf(),
-							gauss);
-					final SubsampleIntervalView<FloatType> subsampled = Views.subsample(filtered, sampleStepSize);
-
-					final RandomAccessibleInterval<FloatType> sourceGridBlock = Views.offsetInterval(subsampled, gridBlock[0], gridBlock[1]);
-
-					N5Utils.saveBlock(sourceGridBlock, n5Writer, outDatasetName, gridBlock[2]);
 				});
 
 		return outDimensions;
@@ -410,43 +414,47 @@ public class SparkGenerateFaceScaleSpace {
 								outDimensions,
 								outBlockSize));
 
-		rdd.foreach(
-				gridBlock -> {
-					System.out.println(Arrays.deepToString(gridBlock));
+		rdd.foreachPartition(
+				blocks -> {
 					final N5Writer n5Writer = N5Util.createN5Writer(n5Path);
-					
-					final RandomAccessibleInterval<RealType<?>> source;
 
-					// only s0 is UnsignedByteType, the rest is FloatType and already inverted and normalized (if asked for)
-					if ( invert || normalizeContrast )
-					{
-						source = (RandomAccessibleInterval<RealType<?>>)(Object) filter(
-								(RandomAccessibleInterval<UnsignedByteType>)N5Utils.open(n5Writer, inDatasetName),
-								invert,
-								normalizeContrast,
-								scaleIndex );
+					while (blocks.hasNext()) {
+						final long[][] gridBlock = blocks.next();
+						System.out.println(Arrays.deepToString(gridBlock));
+
+						final RandomAccessibleInterval<RealType<?>> source;
+
+						// only s0 is UnsignedByteType, the rest is FloatType and already inverted and normalized (if asked for)
+						if ( invert || normalizeContrast )
+						{
+							source = (RandomAccessibleInterval<RealType<?>>)(Object) filter(
+									(RandomAccessibleInterval<UnsignedByteType>)N5Utils.open(n5Writer, inDatasetName),
+									invert,
+									normalizeContrast,
+									scaleIndex );
+						}
+						else
+						{
+							source = (RandomAccessibleInterval)N5Utils.open(n5Writer, inDatasetName);
+						}
+
+						@SuppressWarnings({ "rawtypes", "unchecked" })
+						final RandomAccessibleInterval<FloatType> floatSource =
+								inType == DataType.FLOAT32 ? (RandomAccessibleInterval)source : Converters.convert(
+										source,
+										(a, b) -> b.set(a.getRealFloat()),
+										new FloatType());
+
+						IntervalView<FloatType> roi = Views.offsetInterval(Views.extendZero( floatSource ), absMin, absSize);
+						for (int d = 0; d < roi.numDimensions(); ++d)
+							if (size[d] < 0)
+								roi = Views.invertAxis(roi, d);
+
+						final IntervalView<FloatType> zeroMin = Views.zeroMin(roi);
+						final IntervalView<FloatType> face = Views.hyperSlice(zeroMin, 2, 0);
+						final RandomAccessibleInterval<FloatType> sourceGridBlock = Views.offsetInterval(face, gridBlock[0], gridBlock[1]);
+						N5Utils.saveBlock(sourceGridBlock, n5Writer, outDatasetName, gridBlock[2]);
 					}
-					else
-					{
-						source = (RandomAccessibleInterval)N5Utils.open(n5Writer, inDatasetName);
-					}
-
-					@SuppressWarnings({ "rawtypes", "unchecked" })
-					final RandomAccessibleInterval<FloatType> floatSource =
-							inType == DataType.FLOAT32 ? (RandomAccessibleInterval)source : Converters.convert(
-									source,
-									(a, b) -> b.set(a.getRealFloat()),
-									new FloatType());
-
-					IntervalView<FloatType> roi = Views.offsetInterval(Views.extendZero( floatSource ), absMin, absSize);
-					for (int d = 0; d < roi.numDimensions(); ++d)
-						if (size[d] < 0)
-							roi = Views.invertAxis(roi, d);
-
-					final IntervalView<FloatType> zeroMin = Views.zeroMin(roi);
-					final IntervalView<FloatType> face = Views.hyperSlice(zeroMin, 2, 0);
-					final RandomAccessibleInterval<FloatType> sourceGridBlock = Views.offsetInterval(face, gridBlock[0], gridBlock[1]);
-					N5Utils.saveBlock(sourceGridBlock, n5Writer, outDatasetName, gridBlock[2]);
 				});
 	}
 


### PR DESCRIPTION
This PR optimizes the multi-sem flattening routine. The main changes are:
1. N5 readers/writers and cached cell images are now reused between tasks in a partition by using `mapPartitions` rather than `forEach` to iterate over blocks. This allows for some reuse of cached blocks, but most importantly reduces the number of authentication requests to cloud storage by at least an order of magnitude.
2. Instead of relying on the general `FlattenTransform`, I wrote a kind of `BlockSupplier` (newer versions of `imglib2-algorithm`, which we don't use in this repo yet, provide this as an explicit interface) to do the flattening. This enormously reduces compute cost since the former relies on a 3D n-linear interpolation, when only a cheaper 1D bilinear interpolation in z is needed. This reduces runtime by ~7x.

I tested this on a 10000x10000x80 chunk of data from the middle of the `w61_s079` stack. The output after the changes matches the one from before the changes at the byte level.

Furthermore, I tried to do similar optimizations for the surface extraction code. This code
- extracts a thin range of z-layers from s0
- optionally (and lazily) applies contrast normalization
- applies successive downsampling (= lazy Gauss smoothing and subsampling)
- extracts surfaces from each downsampling level

Because the z-ranges for top and bottom surfaces usually don't overlap there is no duplication in downsampling work. Also, trying to share caches for either raw data or contrast normalized data typically results in OOM errors. This is most likely related to [this fundamental issue with imglib2 caching](https://github.com/imglib/imglib2-cache/issues/25).

For that reason, I was only able to share the N5 creation, which will reduce the number of auth requests if used with cloud storage, but won't affect running time too much. I'll make a clear cut here and address the remaining issues at a later point.