### PR TITLE
Parallelize layer norm

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
@@ -3,6 +3,7 @@ package org.janelia.saalfeldlab.hotknife;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -11,21 +12,32 @@ import java.util.stream.IntStream;
 
 import mpicbg.models.AffineModel1D;
 
+import org.apache.spark.api.java.JavaSparkContext;
+import org.janelia.saalfeldlab.hotknife.util.Grid;
+import org.janelia.saalfeldlab.hotknife.util.N5Util;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.IntegerType;
-import net.imglib2.view.IntervalView;
+import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
 
 
 /**
  * Layer-wise intensity normalization for FIB-SEM data.
  * Uses all non-zero pixels without masking. Supports both shift and scale transformations.
+ * <p>
+ * Histogram computation is parallelized via Spark: the downsampled volume is split into
+ * 3D chunks, each chunk produces per-layer histograms of pixel values, which are merged
+ * across partitions and then on the driver.
  *
  * @param <T> pixel type (8bit or 16bit)
  */
@@ -88,36 +100,126 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 	}
 
 	@Override
-	protected List<AffineModel1D> computeTransformations(final RandomAccessibleInterval<T> rai) {
-		final List<IntervalView<T>> stack = asZStack(rai);
-		final List<LayerHistogram> layerHistograms = new ArrayList<>(stack.size());
+	protected List<AffineModel1D> computeTransformations(
+			final JavaSparkContext sparkContext,
+			final DatasetAttributes downscaledAttributes) {
 
-		// Compute statistics for each layer using all non-zero pixels
-		System.out.println("Computing layer statistics...");
-		System.out.println("layer\tmedian\tmean\tstd\tmin\tmax");
-		for (int z = 0; z < stack.size(); z++) {
-			final List<Double> pixels = new ArrayList<>();
-			for (final T pixel : Views.flatIterable(stack.get(z))) {
-				if (pixel.getInteger() > 0) {
-					pixels.add((double) pixel.getInteger());
+		final int nLayers = (int) downscaledAttributes.getDimensions()[2];
+
+		final LayerHistogram[] layerHistograms = computeHistograms(sparkContext, downscaledAttributes, nLayers);
+
+		return histogramsToTransformations(layerHistograms);
+	}
+
+	private LayerHistogram[] computeHistograms(
+			final JavaSparkContext sparkContext,
+			final DatasetAttributes downscaledAttributes,
+			final int nLayers) {
+
+		final List<long[][]> grid = Grid.create(
+				downscaledAttributes.getDimensions(), downscaledAttributes.getBlockSize());
+
+		final String n5Path = options.n5Path;
+		final String dsInputDataset = downScaledInputDataset;
+		final double cutoff = fibSemOptions.cutoff();
+
+		final List<LayerHistogram[]> partitionResults = sparkContext.parallelize(grid)
+				.mapPartitions(blocks -> {
+					final N5Reader n5 = N5Util.createN5Reader(n5Path);
+					final RandomAccessibleInterval<T> img = N5Utils.open(n5, dsInputDataset);
+
+					final LayerHistogram[] merged = new LayerHistogram[nLayers];
+
+					while (blocks.hasNext()) {
+						processPixelBlock(img, blocks.next(), merged, cutoff);
+					}
+
+					return Collections.singletonList(merged).iterator();
+				})
+				.collect();
+
+		// Merge partition results on driver
+		final LayerHistogram[] globalHistograms = new LayerHistogram[nLayers];
+		for (final LayerHistogram[] partResult : partitionResults) {
+			for (int i = 0; i < nLayers; i++) {
+				if (partResult[i] != null) {
+					if (globalHistograms[i] == null) {
+						globalHistograms[i] = partResult[i];
+					} else {
+						globalHistograms[i] = globalHistograms[i].absorb(partResult[i]);
+					}
 				}
 			}
-			final LayerHistogram histogram = LayerHistogram.from(pixels, fibSemOptions.cutoff());
-			layerHistograms.add(histogram);
-			System.out.printf("%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f%n",
-					z, histogram.median(), histogram.mean(), histogram.std(), histogram.min(), histogram.max());
 		}
 
-		// Precompute scale and shift values to avoid repeated recomputation from histograms
-		final double[] scaleValues = layerHistograms.stream()
-				.mapToDouble(s -> fibSemOptions.scale().get(s))
-				.toArray();
-		final double[] shiftValues = layerHistograms.stream()
-				.mapToDouble(s -> fibSemOptions.shift().from(s))
-				.toArray();
+		return globalHistograms;
+	}
+
+	private static <T extends NativeType<T> & IntegerType<T>> void processPixelBlock(
+			final RandomAccessibleInterval<T> img,
+			final long[][] gridBlock,
+			final LayerHistogram[] merged,
+			final double cutoff) {
+
+		final int zStart = (int) gridBlock[0][2];
+		final int zSize = (int) gridBlock[1][2];
+
+		final FinalInterval interval = Intervals.createMinSize(
+				gridBlock[0][0], gridBlock[0][1], gridBlock[0][2],
+				gridBlock[1][0], gridBlock[1][1], gridBlock[1][2]);
+		final RandomAccessibleInterval<T> chunk = Views.interval(img, interval);
+
+		for (int z = 0; z < zSize; z++) {
+			final int globalZ = zStart + z;
+
+			final RandomAccessibleInterval<T> layer = Views.hyperSlice(chunk, 2, z);
+
+			final List<Double> pixels = new ArrayList<>();
+			final Cursor<T> cursor = Views.flatIterable(layer).cursor();
+
+			while (cursor.hasNext()) {
+				final int val = cursor.next().getInteger();
+				if (val > 0) {
+					pixels.add((double) val);
+				}
+			}
+
+			if (!pixels.isEmpty()) {
+				final LayerHistogram blockHistogram = LayerHistogram.from(pixels, cutoff);
+				if (merged[globalZ] == null) {
+					merged[globalZ] = blockHistogram;
+				} else {
+					merged[globalZ].absorb(blockHistogram);
+				}
+			}
+		}
+	}
+
+	private List<AffineModel1D> histogramsToTransformations(final LayerHistogram[] layerHistograms) {
+		// Print diagnostic output
+		System.out.println("Computing layer statistics...");
+		System.out.println("layer\tmedian\tmean\tstd\tmin\tmax");
+		for (int z = 0; z < layerHistograms.length; z++) {
+			final LayerHistogram histogram = layerHistograms[z];
+			if (histogram != null) {
+				System.out.printf("%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f%n",
+								  z, histogram.median(), histogram.mean(), histogram.std(), histogram.min(), histogram.max());
+			} else {
+				System.out.printf("%d\t-\t-\t-\t-\t-%n", z);
+			}
+		}
+
+		// Precompute scale and shift values
+		final double[] scaleValues = new double[layerHistograms.length];
+		final double[] shiftValues = new double[layerHistograms.length];
+		for (int i = 0; i < layerHistograms.length; i++) {
+			if (layerHistograms[i] != null) {
+				scaleValues[i] = fibSemOptions.scale().get(layerHistograms[i]);
+				shiftValues[i] = fibSemOptions.shift().from(layerHistograms[i]);
+			}
+		}
 
 		// Determine the target shift and scale based on the layer with the maximum scale
-		// which maximizes the expressive range while minimizing the risk of clipping
 		final int maxScaleIndex = IntStream.range(0, scaleValues.length)
 				.boxed()
 				.max(Comparator.comparingDouble(i -> scaleValues[i]))
@@ -125,11 +227,11 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 		final double targetShift = shiftValues[maxScaleIndex];
 		final double targetScale = scaleValues[maxScaleIndex];
 		System.out.printf("Target layer: %d, targetShift: %.2f, targetScale: %.2f%n",
-				maxScaleIndex, targetShift, targetScale);
+						  maxScaleIndex, targetShift, targetScale);
 
 		// Compute intensity transformations for each layer
-		final List<AffineModel1D> models = new ArrayList<>(stack.size());
-		for (int i = 0; i < layerHistograms.size(); i++) {
+		final List<AffineModel1D> models = new ArrayList<>(layerHistograms.length);
+		for (int i = 0; i < layerHistograms.length; i++) {
 			final AffineModel1D model = new AffineModel1D();
 			final double scale = targetScale / scaleValues[i];
 			final double shift = targetShift - shiftValues[i] * scale;

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
@@ -106,6 +106,8 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 
 		final int nLayers = (int) downscaledAttributes.getDimensions()[2];
 
+		logMessage("computeTransformations: entry, nLayers="  + nLayers);
+
 		final LayerHistogram[] layerHistograms = computeHistograms(sparkContext, downscaledAttributes, nLayers);
 
 		return histogramsToTransformations(layerHistograms);
@@ -115,6 +117,9 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 			final JavaSparkContext sparkContext,
 			final DatasetAttributes downscaledAttributes,
 			final int nLayers) {
+
+
+		logMessage("computeHistograms: entry, nLayers="  + nLayers);
 
 		final List<long[][]> grid = Grid.create(
 				downscaledAttributes.getDimensions(), downscaledAttributes.getBlockSize());
@@ -151,6 +156,8 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 				}
 			}
 		}
+
+		logMessage("computeHistograms: exit, returning "  + globalHistograms.length + " histograms");
 
 		return globalHistograms;
 	}
@@ -197,6 +204,9 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 	}
 
 	private List<AffineModel1D> histogramsToTransformations(final LayerHistogram[] layerHistograms) {
+
+		logMessage("histogramsToTransformations: entry");
+
 		// Print diagnostic output
 		System.out.println("Computing layer statistics...");
 		System.out.println("layer\tmedian\tmean\tstd\tmin\tmax");
@@ -240,6 +250,12 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 			models.add(model);
 		}
 
+		logMessage("histogramsToTransformations: exit, returning " + models.size() + " models");
+
 		return models;
+	}
+
+	private static void logMessage(final String message) {
+		org.janelia.saalfeldlab.hotknife.util.Util.logMessage(FibSemNormalizeLayerIntensity.class.getName(), message);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
@@ -121,8 +121,7 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 
 		// Compute intensity transformations for each layer
 		final List<AffineModel1D> models = new ArrayList<>(stack.size());
-		for (int z = 0; z < layerStats.size(); z++) {
-			final LayerStats stats = layerStats.get(z);
+		for (final LayerStats stats : layerStats) {
 			final AffineModel1D model = new AffineModel1D();
 			final double scale = targetScale / fibSemOptions.scale().get(stats);
 			final double shift = targetShift - fibSemOptions.shift().from(stats) * scale;

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
@@ -72,6 +72,15 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 		protected ScaleType scale() {
 			return scale;
 		}
+
+		@Override
+		public String toString() {
+			return "FibSemNormalizeLayerIntensity.Options { " +
+				   super.toString() +
+				   ", shift=" + shift +
+				   ", scale=" + scale +
+				   " }";
+		}
 	}
 
 	public static void main(final String... args) throws IOException, InterruptedException, ExecutionException {

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
@@ -168,11 +168,12 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 				gridBlock[0][0], gridBlock[0][1], gridBlock[0][2],
 				gridBlock[1][0], gridBlock[1][1], gridBlock[1][2]);
 		final RandomAccessibleInterval<T> chunk = Views.interval(img, interval);
+		final long zMin = chunk.min(2);
 
 		for (int z = 0; z < zSize; z++) {
 			final int globalZ = zStart + z;
 
-			final RandomAccessibleInterval<T> layer = Views.hyperSlice(chunk, 2, z);
+			final RandomAccessibleInterval<T> layer = Views.hyperSlice(chunk, 2, zMin + z);
 
 			final List<Double> pixels = new ArrayList<>();
 			final Cursor<T> cursor = Views.flatIterable(layer).cursor();

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/FibSemNormalizeLayerIntensity.java
@@ -90,7 +90,7 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 	@Override
 	protected List<AffineModel1D> computeTransformations(final RandomAccessibleInterval<T> rai) {
 		final List<IntervalView<T>> stack = asZStack(rai);
-		final List<LayerStats> layerStats = new ArrayList<>(stack.size());
+		final List<LayerHistogram> layerHistograms = new ArrayList<>(stack.size());
 
 		// Compute statistics for each layer using all non-zero pixels
 		System.out.println("Computing layer statistics...");
@@ -102,29 +102,37 @@ public class FibSemNormalizeLayerIntensity<T extends NativeType<T> & IntegerType
 					pixels.add((double) pixel.getInteger());
 				}
 			}
-			final LayerStats stats = LayerStats.from(pixels, fibSemOptions.cutoff());
-			layerStats.add(stats);
+			final LayerHistogram histogram = LayerHistogram.from(pixels, fibSemOptions.cutoff());
+			layerHistograms.add(histogram);
 			System.out.printf("%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f%n",
-					z, stats.median, stats.mean, stats.std, stats.min, stats.max);
+					z, histogram.median(), histogram.mean(), histogram.std(), histogram.min(), histogram.max());
 		}
+
+		// Precompute scale and shift values to avoid repeated recomputation from histograms
+		final double[] scaleValues = layerHistograms.stream()
+				.mapToDouble(s -> fibSemOptions.scale().get(s))
+				.toArray();
+		final double[] shiftValues = layerHistograms.stream()
+				.mapToDouble(s -> fibSemOptions.shift().from(s))
+				.toArray();
 
 		// Determine the target shift and scale based on the layer with the maximum scale
 		// which maximizes the expressive range while minimizing the risk of clipping
-		final int maxScaleIndex = IntStream.range(0, layerStats.size())
+		final int maxScaleIndex = IntStream.range(0, scaleValues.length)
 				.boxed()
-				.max(Comparator.comparingDouble(i -> fibSemOptions.scale().get(layerStats.get(i))))
+				.max(Comparator.comparingDouble(i -> scaleValues[i]))
 				.orElseThrow(NoSuchElementException::new);
-		final double targetShift = fibSemOptions.shift().from(layerStats.get(maxScaleIndex));
-		final double targetScale = fibSemOptions.scale().get(layerStats.get(maxScaleIndex));
+		final double targetShift = shiftValues[maxScaleIndex];
+		final double targetScale = scaleValues[maxScaleIndex];
 		System.out.printf("Target layer: %d, targetShift: %.2f, targetScale: %.2f%n",
 				maxScaleIndex, targetShift, targetScale);
 
 		// Compute intensity transformations for each layer
 		final List<AffineModel1D> models = new ArrayList<>(stack.size());
-		for (final LayerStats stats : layerStats) {
+		for (int i = 0; i < layerHistograms.size(); i++) {
 			final AffineModel1D model = new AffineModel1D();
-			final double scale = targetScale / fibSemOptions.scale().get(stats);
-			final double shift = targetShift - fibSemOptions.shift().from(stats) * scale;
+			final double scale = targetScale / scaleValues[i];
+			final double shift = targetShift - shiftValues[i] * scale;
 			model.set(scale, shift);
 			models.add(model);
 		}

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
@@ -137,15 +137,15 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 				}
 			}
 
-			// Compute layer shift using LayerStats for robust aggregation
+			// Compute layer shift using LayerHistogram for robust aggregation
 			double layerShift = 0.0;
 			if (!shifts.isEmpty()) {
-				final LayerStats stats = LayerStats.from(shifts, multiSemOptions.cutoff());
-				layerShift = (multiSemOptions.aggregation() == AggregationType.MEDIAN) ? stats.median : stats.mean;
+				final LayerHistogram histogram = LayerHistogram.from(shifts, multiSemOptions.cutoff());
+				layerShift = (multiSemOptions.aggregation() == AggregationType.MEDIAN) ? histogram.median() : histogram.mean();
 				cumulativeShift += layerShift;
 
 				System.out.printf("%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f%n",
-						z + 1, shifts.size(), stats.median, stats.mean, stats.std, stats.min, stats.max,
+						z + 1, shifts.size(), histogram.median(), histogram.mean(), histogram.std(), histogram.min(), histogram.max(),
 						layerShift, cumulativeShift);
 			} else {
 				System.out.printf("%d\t0\t-\t-\t-\t-\t-\t%.2f\t%.2f%n",

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
@@ -130,8 +130,11 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 			final DatasetAttributes downscaledAttributes,
 			final int nLayerPairs) {
 
-		final List<long[][]> grid = Grid.create(
-				downscaledAttributes.getDimensions(), downscaledAttributes.getBlockSize());
+		// Use full z-extent as block size so each grid element is an XY column spanning all layers
+		final long[] dims = downscaledAttributes.getDimensions();
+		final int[] blockSize = downscaledAttributes.getBlockSize();
+		final int[] columnBlockSize = new int[]{blockSize[0], blockSize[1], (int) dims[2]};
+		final List<long[][]> grid = Grid.create(dims, columnBlockSize);
 
 		final String n5Path = options.n5Path;
 		final String dsInputDataset = downScaledInputDataset;
@@ -147,7 +150,7 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 					final LayerHistogram[] merged = new LayerHistogram[nLayerPairs];
 
 					while (blocks.hasNext()) {
-						processShiftBlock(img, blocks.next(), merged, lowerThreshold, upperThreshold, cutoff);
+						processShiftColumn(img, blocks.next(), merged, lowerThreshold, upperThreshold, cutoff);
 					}
 
 					return Collections.singletonList(merged).iterator();
@@ -171,7 +174,7 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 		return globalHistograms;
 	}
 
-	private static void processShiftBlock(
+	private static void processShiftColumn(
 			final RandomAccessibleInterval<UnsignedByteType> img,
 			final long[][] gridBlock,
 			final LayerHistogram[] merged,
@@ -179,24 +182,16 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 			final int upperThreshold,
 			final double cutoff) {
 
-		final int zStart = (int) gridBlock[0][2];
-		final int zSize = (int) gridBlock[1][2];
-
-		// Extend one layer before to capture the cross-block boundary pair
-		final int extendedZStart = Math.max(0, zStart - 1);
-		final int extendedZSize = zSize + (zStart - extendedZStart);
-
 		final FinalInterval interval = Intervals.createMinSize(
-				gridBlock[0][0], gridBlock[0][1], extendedZStart,
-				gridBlock[1][0], gridBlock[1][1], extendedZSize);
-		final RandomAccessibleInterval<UnsignedByteType> chunk = Views.interval(img, interval);
-		final long zMin = chunk.min(2);
+				gridBlock[0][0], gridBlock[0][1], gridBlock[0][2],
+				gridBlock[1][0], gridBlock[1][1], gridBlock[1][2]);
+		final RandomAccessibleInterval<UnsignedByteType> column = Views.interval(img, interval);
+		final long zMin = column.min(2);
+		final int nLayers = (int) column.dimension(2);
 
-		for (int z = 0; z < extendedZSize - 1; z++) {
-			final int globalZ = extendedZStart + z;
-
-			final Cursor<UnsignedByteType> currentLayer = Views.flatIterable(Views.hyperSlice(chunk, 2, zMin + z)).cursor();
-			final Cursor<UnsignedByteType> nextLayer = Views.flatIterable(Views.hyperSlice(chunk, 2, zMin + z + 1)).cursor();
+		for (int z = 0; z < nLayers - 1; z++) {
+			final Cursor<UnsignedByteType> currentLayer = Views.flatIterable(Views.hyperSlice(column, 2, zMin + z)).cursor();
+			final Cursor<UnsignedByteType> nextLayer = Views.flatIterable(Views.hyperSlice(column, 2, zMin + z + 1)).cursor();
 
 			final List<Double> shifts = new ArrayList<>();
 
@@ -212,10 +207,10 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 
 			if (!shifts.isEmpty()) {
 				final LayerHistogram blockHistogram = LayerHistogram.from(shifts, cutoff);
-				if (merged[globalZ] == null) {
-					merged[globalZ] = blockHistogram;
+				if (merged[z] == null) {
+					merged[z] = blockHistogram;
 				} else {
-					merged[globalZ].absorb(blockHistogram);
+					merged[z].absorb(blockHistogram);
 				}
 			}
 		}

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
@@ -182,16 +182,21 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 		final int zStart = (int) gridBlock[0][2];
 		final int zSize = (int) gridBlock[1][2];
 
+		// Extend one layer before to capture the cross-block boundary pair
+		final int extendedZStart = Math.max(0, zStart - 1);
+		final int extendedZSize = zSize + (zStart - extendedZStart);
+
 		final FinalInterval interval = Intervals.createMinSize(
-				gridBlock[0][0], gridBlock[0][1], gridBlock[0][2],
-				gridBlock[1][0], gridBlock[1][1], gridBlock[1][2]);
+				gridBlock[0][0], gridBlock[0][1], extendedZStart,
+				gridBlock[1][0], gridBlock[1][1], extendedZSize);
 		final RandomAccessibleInterval<UnsignedByteType> chunk = Views.interval(img, interval);
+		final long zMin = chunk.min(2);
 
-		for (int z = 0; z < zSize - 1; z++) {
-			final int globalZ = zStart + z;
+		for (int z = 0; z < extendedZSize - 1; z++) {
+			final int globalZ = extendedZStart + z;
 
-			final Cursor<UnsignedByteType> currentLayer = Views.flatIterable(Views.hyperSlice(chunk, 2, z)).cursor();
-			final Cursor<UnsignedByteType> nextLayer = Views.flatIterable(Views.hyperSlice(chunk, 2, z + 1)).cursor();
+			final Cursor<UnsignedByteType> currentLayer = Views.flatIterable(Views.hyperSlice(chunk, 2, zMin + z)).cursor();
+			final Cursor<UnsignedByteType> nextLayer = Views.flatIterable(Views.hyperSlice(chunk, 2, zMin + z + 1)).cursor();
 
 			final List<Double> shifts = new ArrayList<>();
 

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
@@ -3,20 +3,27 @@ package org.janelia.saalfeldlab.hotknife;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import mpicbg.models.AffineModel1D;
 
+import org.apache.spark.api.java.JavaSparkContext;
+import org.janelia.saalfeldlab.hotknife.util.Grid;
+import org.janelia.saalfeldlab.hotknife.util.N5Util;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
 import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
-import net.imglib2.view.IntervalView;
+import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
 
 
@@ -25,6 +32,10 @@ import net.imglib2.view.Views;
  * Computes intensity shifts between adjacent layers, using only pixels where both layers
  * have valid tissue (within threshold). This naturally handles non-flat substrate boundaries
  * by excluding pixel pairs where one is substrate.
+ * <p>
+ * Histogram computation is parallelized via Spark: the downsampled volume is split into
+ * 3D chunks, each chunk produces per-layer-pair histograms, which are merged across
+ * partitions and then on the driver.
  * <p>
  * Only supports 8-bit data and shift transformations (no scaling).
  */
@@ -101,9 +112,112 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 	}
 
 	@Override
-	protected List<AffineModel1D> computeTransformations(final RandomAccessibleInterval<UnsignedByteType> rai) {
-		final List<IntervalView<UnsignedByteType>> stack = asZStack(rai);
-		final List<AffineModel1D> models = new ArrayList<>(stack.size());
+	protected List<AffineModel1D> computeTransformations(
+			final JavaSparkContext sparkContext,
+			final DatasetAttributes downscaledAttributes) {
+
+		final int nLayers = (int) downscaledAttributes.getDimensions()[2];
+		final int nLayerPairs = nLayers - 1;
+
+		final LayerHistogram[] globalHistograms = computeHistograms(
+				sparkContext, downscaledAttributes, nLayerPairs);
+
+		return histogramsToTransformations(globalHistograms);
+	}
+
+	private LayerHistogram[] computeHistograms(
+			final JavaSparkContext sparkContext,
+			final DatasetAttributes downscaledAttributes,
+			final int nLayerPairs) {
+
+		final List<long[][]> grid = Grid.create(
+				downscaledAttributes.getDimensions(), downscaledAttributes.getBlockSize());
+
+		final String n5Path = options.n5Path;
+		final String dsInputDataset = downScaledInputDataset;
+		final int lowerThreshold = multiSemOptions.lowerThreshold();
+		final int upperThreshold = multiSemOptions.upperThreshold();
+		final double cutoff = multiSemOptions.cutoff();
+
+		final List<LayerHistogram[]> partitionResults = sparkContext.parallelize(grid)
+				.mapPartitions(blocks -> {
+					final N5Reader n5 = N5Util.createN5Reader(n5Path);
+					final RandomAccessibleInterval<UnsignedByteType> img = N5Utils.open(n5, dsInputDataset);
+
+					final LayerHistogram[] merged = new LayerHistogram[nLayerPairs];
+
+					while (blocks.hasNext()) {
+						processShiftBlock(img, blocks.next(), merged, lowerThreshold, upperThreshold, cutoff);
+					}
+
+					return Collections.singletonList(merged).iterator();
+				})
+				.collect();
+
+		// Merge partition results on driver
+		final LayerHistogram[] globalHistograms = new LayerHistogram[nLayerPairs];
+		for (final LayerHistogram[] partResult : partitionResults) {
+			for (int i = 0; i < nLayerPairs; i++) {
+				if (partResult[i] != null) {
+					if (globalHistograms[i] == null) {
+						globalHistograms[i] = partResult[i];
+					} else {
+						globalHistograms[i].absorb(partResult[i]);
+					}
+				}
+			}
+		}
+
+		return globalHistograms;
+	}
+
+	private static void processShiftBlock(
+			final RandomAccessibleInterval<UnsignedByteType> img,
+			final long[][] gridBlock,
+			final LayerHistogram[] merged,
+			final int lowerThreshold,
+			final int upperThreshold,
+			final double cutoff) {
+
+		final int zStart = (int) gridBlock[0][2];
+		final int zSize = (int) gridBlock[1][2];
+
+		final FinalInterval interval = Intervals.createMinSize(
+				gridBlock[0][0], gridBlock[0][1], gridBlock[0][2],
+				gridBlock[1][0], gridBlock[1][1], gridBlock[1][2]);
+		final RandomAccessibleInterval<UnsignedByteType> chunk = Views.interval(img, interval);
+
+		for (int z = 0; z < zSize - 1; z++) {
+			final int globalZ = zStart + z;
+
+			final Cursor<UnsignedByteType> currentLayer = Views.flatIterable(Views.hyperSlice(chunk, 2, z)).cursor();
+			final Cursor<UnsignedByteType> nextLayer = Views.flatIterable(Views.hyperSlice(chunk, 2, z + 1)).cursor();
+
+			final List<Double> shifts = new ArrayList<>();
+
+			while (currentLayer.hasNext()) {
+				final int valCurrent = currentLayer.next().getInteger();
+				final int valNext = nextLayer.next().getInteger();
+
+				if (valCurrent >= lowerThreshold && valCurrent <= upperThreshold
+						&& valNext >= lowerThreshold && valNext <= upperThreshold) {
+					shifts.add((double) (valNext - valCurrent));
+				}
+			}
+
+			if (!shifts.isEmpty()) {
+				final LayerHistogram blockHistogram = LayerHistogram.from(shifts, cutoff);
+				if (merged[globalZ] == null) {
+					merged[globalZ] = blockHistogram;
+				} else {
+					merged[globalZ].absorb(blockHistogram);
+				}
+			}
+		}
+	}
+
+	private List<AffineModel1D> histogramsToTransformations(final LayerHistogram[] histograms) {
+		final List<AffineModel1D> models = new ArrayList<>(histograms.length + 1);
 
 		// First layer has identity transform (reference)
 		final AffineModel1D identity = new AffineModel1D();
@@ -117,51 +231,29 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 		System.out.println("layer\tnValid\tmedian\tmean\tstd\tmin\tmax\tlayerShift\tcumulativeShift");
 		System.out.printf("%d\t-\t-\t-\t-\t-\t-\t%.2f\t%.2f%n", 0, 0.0, 0.0);
 
-		// Compute shifts between adjacent layers
-		for (int z = 0; z < stack.size() - 1; z++) {
-			final IntervalView<UnsignedByteType> currentLayer = stack.get(z);
-			final IntervalView<UnsignedByteType> nextLayer = stack.get(z + 1);
-
-			// Collect valid shifts between adjacent layers
-			final List<Double> shifts = new ArrayList<>();
-			final Cursor<UnsignedByteType> cursorCurrent = Views.flatIterable(currentLayer).cursor();
-			final Cursor<UnsignedByteType> cursorNext = Views.flatIterable(nextLayer).cursor();
-
-			while (cursorCurrent.hasNext()) {
-				final int valCurrent = cursorCurrent.next().getInteger();
-				final int valNext = cursorNext.next().getInteger();
-
-				// Only record shift if BOTH pixels are within threshold (valid tissue)
-				if (isWithinThreshold(valCurrent) && isWithinThreshold(valNext)) {
-					shifts.add((double) (valNext - valCurrent));
-				}
-			}
-
-			// Compute layer shift using LayerHistogram for robust aggregation
+		for (int z = 0; z < histograms.length; z++) {
 			double layerShift = 0.0;
-			if (!shifts.isEmpty()) {
-				final LayerHistogram histogram = LayerHistogram.from(shifts, multiSemOptions.cutoff());
-				layerShift = (multiSemOptions.aggregation() == AggregationType.MEDIAN) ? histogram.median() : histogram.mean();
+			final LayerHistogram histogram = histograms[z];
+
+			if (histogram != null) {
+				layerShift = (multiSemOptions.aggregation() == AggregationType.MEDIAN)
+						? histogram.median() : histogram.mean();
 				cumulativeShift += layerShift;
 
 				System.out.printf("%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f%n",
-						z + 1, shifts.size(), histogram.median(), histogram.mean(), histogram.std(), histogram.min(), histogram.max(),
-						layerShift, cumulativeShift);
+								  z + 1, histogram.totalCount(), histogram.median(), histogram.mean(),
+								  histogram.std(), histogram.min(), histogram.max(),
+								  layerShift, cumulativeShift);
 			} else {
 				System.out.printf("%d\t0\t-\t-\t-\t-\t-\t%.2f\t%.2f%n",
-						z + 1, layerShift, cumulativeShift);
+								  z + 1, layerShift, cumulativeShift);
 			}
 
-			// Create model: new_val = old_val - cumulativeShift (to normalize to layer 0)
 			final AffineModel1D model = new AffineModel1D();
 			model.set(1.0, -cumulativeShift);
 			models.add(model);
 		}
 
 		return models;
-	}
-
-	private boolean isWithinThreshold(final int value) {
-		return value >= multiSemOptions.lowerThreshold() && value <= multiSemOptions.upperThreshold();
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
@@ -86,6 +86,16 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 		public int upperThreshold() {
 			return upperThreshold;
 		}
+
+		@Override
+		public String toString() {
+			return "MultiSemNormalizeLayerIntensity.Options { " +
+				   super.toString() +
+				   ", aggregation=" + aggregation +
+				   ", lowerThreshold=" + lowerThreshold +
+				   ", upperThreshold=" + upperThreshold +
+				   " }";
+		}
 	}
 
 	public static void main(final String... args) throws IOException, InterruptedException, ExecutionException {

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensity.java
@@ -119,6 +119,8 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 		final int nLayers = (int) downscaledAttributes.getDimensions()[2];
 		final int nLayerPairs = nLayers - 1;
 
+		logMessage("computeTransformations: entry, nLayerPairs="  + nLayerPairs);
+
 		final LayerHistogram[] globalHistograms = computeHistograms(
 				sparkContext, downscaledAttributes, nLayerPairs);
 
@@ -129,6 +131,8 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 			final JavaSparkContext sparkContext,
 			final DatasetAttributes downscaledAttributes,
 			final int nLayerPairs) {
+
+		logMessage("computeHistograms: entry, nLayerPairs="  + nLayerPairs);
 
 		// Use full z-extent as block size so each grid element is an XY column spanning all layers
 		final long[] dims = downscaledAttributes.getDimensions();
@@ -170,6 +174,8 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 				}
 			}
 		}
+
+		logMessage("computeHistograms: exit, returning "  + globalHistograms.length + " histograms");
 
 		return globalHistograms;
 	}
@@ -217,6 +223,9 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 	}
 
 	private List<AffineModel1D> histogramsToTransformations(final LayerHistogram[] histograms) {
+
+		logMessage("histogramsToTransformations: entry");
+
 		final List<AffineModel1D> models = new ArrayList<>(histograms.length + 1);
 
 		// First layer has identity transform (reference)
@@ -254,6 +263,12 @@ public class MultiSemNormalizeLayerIntensity extends SparkNormalizeLayerIntensit
 			models.add(model);
 		}
 
+		logMessage("histogramsToTransformations: exit, returning " + models.size() + " models");
+
 		return models;
+	}
+
+	private static void logMessage(final String message) {
+		org.janelia.saalfeldlab.hotknife.util.Util.logMessage(MultiSemNormalizeLayerIntensity.class.getName(), message);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensityHistogram.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensityHistogram.java
@@ -23,14 +23,12 @@ import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
 
 import net.imglib2.Cursor;
-import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
 
 /**
@@ -165,12 +163,14 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			}
 			System.out.println("Computed per-section LUTs against reference z=" + options.refIndex());
 
-			// Pass 2: 3D block grid, apply LUT[z] to every pixel. Layers with no in-tissue
-			// pixels have an identity LUT from buildLut so they pass through unchanged.
+			// Pass 2: 3D block grid, apply LUT[z] inside the tissue mask; out-of-tissue
+			// pixels pass through unchanged. Layers with no in-tissue pixels still carry
+			// an identity LUT from buildLut, so their behaviour is always a no-op.
 			final Broadcast<int[][]> lutsBc = sc.broadcast(luts);
 			final List<long[][]> grid = Grid.create(dims, blockSize);
 			sc.parallelize(grid).foreach(block ->
-					processBlock(n5Path, inDataset, outDataset, block, lutsBc.value()));
+					processBlock(n5Path, inDataset, outDataset, hfDataset, block,
+							lutsBc.value(), factorsBc.value()));
 		}
 
 		System.out.println("wrote " + options.n5Path() + "/" + options.n5DatasetOutput());
@@ -310,29 +310,48 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			final String n5Path,
 			final String inDataset,
 			final String outDataset,
+			final String hfDataset,
 			final long[][] gridBlock,
-			final int[][] luts) {
+			final int[][] luts,
+			final double[] factors) {
 
 		final N5Writer n5 = N5Util.createN5Writer(n5Path);
 		final RandomAccessibleInterval<UnsignedByteType> volume = N5Utils.open(n5, inDataset);
+		final RandomAccessibleInterval<FloatType> hfRai = N5Utils.open(n5, hfDataset);
 
+		final long x0 = gridBlock[0][0];
+		final long y0 = gridBlock[0][1];
 		final long z0 = gridBlock[0][2];
+		final long x1 = x0 + gridBlock[1][0] - 1;
+		final long y1 = y0 + gridBlock[1][1] - 1;
 
-		final FinalInterval blockInterval = Intervals.createMinSize(
-				gridBlock[0][0], gridBlock[0][1], gridBlock[0][2],
-				gridBlock[1][0], gridBlock[1][1], gridBlock[1][2]);
+		final RandomAccessibleInterval<DoubleType> hfAtRawScale = Views.interval(
+				Views.raster(Transform.scaleAndShiftHeightFieldAndValues(hfRai, factors)),
+				new long[]{x0, y0},
+				new long[]{x1, y1});
 
 		final long[] blockDims = new long[]{gridBlock[1][0], gridBlock[1][1], gridBlock[1][2]};
 		final Img<UnsignedByteType> out = ArrayImgs.unsignedBytes(blockDims);
 
-		final Cursor<UnsignedByteType> srcCur = Views.flatIterable(Views.interval(volume, blockInterval)).cursor();
-		final Cursor<UnsignedByteType> dstCur = Views.flatIterable(out).localizingCursor();
+		for (long zOff = 0; zOff < blockDims[2]; zOff++) {
+			final long z = zOff + z0;
+			final int[] lutZ = luts[(int) z];
 
-		while (dstCur.hasNext()) {
-			final UnsignedByteType dst = dstCur.next();
-			final int v = srcCur.next().get();
-			final long z = dstCur.getLongPosition(2) + z0;
-			dst.set(luts[(int) z][v]);
+			final RandomAccessibleInterval<UnsignedByteType> srcSlice = Views.interval(
+					Views.hyperSlice(volume, 2, z),
+					new long[]{x0, y0},
+					new long[]{x1, y1});
+			final RandomAccessibleInterval<UnsignedByteType> dstSlice = Views.hyperSlice(out, 2, zOff);
+
+			final Cursor<UnsignedByteType> srcCur = Views.flatIterable(srcSlice).cursor();
+			final Cursor<UnsignedByteType> dstCur = Views.flatIterable(dstSlice).cursor();
+			final Cursor<DoubleType> hfCur = Views.flatIterable(hfAtRawScale).cursor();
+
+			while (dstCur.hasNext()) {
+				final int v = srcCur.next().get();
+				final double hfVal = hfCur.next().get();
+				dstCur.next().set(z > hfVal ? v : lutZ[v]);   // Note: height-check is less conservative than in histogram computation
+			}
 		}
 
 		N5Utils.saveNonEmptyBlock(out, n5, outDataset, gridBlock[2], new UnsignedByteType());

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensityHistogram.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensityHistogram.java
@@ -59,12 +59,10 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 		private String n5DatasetOutput = null;
 
 		@Option(name = "--heightfieldDataset", required = true,
-				usage = "2D height field dataset (FloatType), e.g. w61_s082/heightfield_1/s1/max")
+				usage = "2D height field dataset (FloatType), e.g. w61_s082/heightfield_1/s1/max. " +
+						"Resolution relative to the raw is read from the 'downsamplingFactors' " +
+						"attribute on the parent group (as written by SparkSurfaceFit).")
 		private String heightfieldDataset = null;
-
-		@Option(name = "--hfDownsample",
-				usage = "XY downsample factor of the heightfield relative to the raw (default: 2)")
-		private int hfDownsample = 2;
 
 		@Option(name = "--refIndex",
 				usage = "Z index of the reference section (default: 5)")
@@ -85,7 +83,6 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 		public String n5DatasetInput() { return n5DatasetInput; }
 		public String n5DatasetOutput() { return n5DatasetOutput; }
 		public String heightfieldDataset() { return heightfieldDataset; }
-		public int hfDownsample() { return hfDownsample; }
 		public int refIndex() { return refIndex; }
 	}
 
@@ -103,6 +100,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 		final int[] blockSize;
 		final float[] hf;
 		final long[] hfShape;
+		final double[] factors;
 
 		try (final N5Reader n5 = N5Util.createN5Reader(options.n5Path())) {
 
@@ -131,6 +129,10 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			while (c.hasNext()) {
 				hf[i++] = c.next().get();
 			}
+
+			factors = readHeightfieldFactors(n5, options.heightfieldDataset());
+			System.out.println("Heightfield downsamplingFactors = [" +
+					factors[0] + ", " + factors[1] + ", " + factors[2] + "]");
 		}
 
 		try (final N5Writer w = N5Util.createN5Writer(options.n5Path())) {
@@ -142,7 +144,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 		try (final JavaSparkContext sc = new JavaSparkContext(conf)) {
 
 			final Broadcast<float[]> hfBc = sc.broadcast(hf);
-			final int hfDs = options.hfDownsample();
+			final Broadcast<double[]> factorsBc = sc.broadcast(factors);
 			final String n5Path = options.n5Path();
 			final String inDataset = options.n5DatasetInput();
 			final String outDataset = options.n5DatasetOutput();
@@ -155,7 +157,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 					new int[]{blockSize[0], blockSize[1]});
 
 			final List<LayerHistogram> sectionHists = sc.parallelize(xyGrid)
-					.map(block -> columnHistograms(n5Path, inDataset, block, numZ, hfBc.value(), hfShape, hfDs))
+					.map(block -> columnHistograms(n5Path, inDataset, block, numZ, hfBc.value(), hfShape, factorsBc.value()))
 					.reduce(MultiSemNormalizeLayerIntensityHistogram::mergeSectionHists);
 
 			final double[] refCdf = cdf256(sectionHists.get(options.refIndex()));
@@ -170,7 +172,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			final List<long[][]> grid = Grid.create(dims, blockSize);
 			sc.parallelize(grid).foreach(block ->
 					processBlock(n5Path, inDataset, outDataset, block,
-								 lutsBc.value(), hfBc.value(), hfShape, hfDs));
+								 lutsBc.value(), hfBc.value(), hfShape, factorsBc.value()));
 		}
 
 		System.out.println("wrote " + options.n5Path() + "/" + options.n5DatasetOutput());
@@ -188,7 +190,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			final int numZ,
 			final float[] hf,
 			final long[] hfShape,
-			final int hfDownsample) {
+			final double[] factors) {
 
 		final N5Reader n5 = N5Util.createN5Reader(n5Path);
 		final RandomAccessibleInterval<UnsignedByteType> volume = N5Utils.open(n5, inDataset);
@@ -210,7 +212,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 				final int v = c.next().get();
 				final long x = c.getLongPosition(0);
 				final long y = c.getLongPosition(1);
-				if (inTissue(z, x, y, hf, hfShape, hfDownsample)) {
+				if (inTissue(z, x, y, hf, hfShape, factors)) {
 					counts[v]++;
 				}
 			}
@@ -230,10 +232,35 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 
 	private static boolean inTissue(
 			final long z, final long x, final long y,
-			final float[] hf, final long[] hfShape, final int hfDownsample) {
-		final long hx = Math.min(x / hfDownsample, hfShape[0] - 1);
-		final long hy = Math.min(y / hfDownsample, hfShape[1] - 1);
-		return z < hf[(int)(hy * hfShape[0] + hx)];
+			final float[] hf, final long[] hfShape, final double[] factors) {
+		final long hx = Math.min((long)(x / factors[0]), hfShape[0] - 1);
+		final long hy = Math.min((long)(y / factors[1]), hfShape[1] - 1);
+		final double val = hf[(int)(hy * hfShape[0] + hx)] * factors[2];
+		return z < val;
+	}
+
+	/**
+	 * Read the heightfield's downsampling factors relative to the raw volume. Looks on the
+	 * parent group first (where {@link SparkSurfaceFit} writes the attribute), falling back
+	 * to the dataset itself. Returns a 3-element [xF, yF, zF] array.
+	 */
+	private static double[] readHeightfieldFactors(final N5Reader n5, final String heightfieldDataset) {
+		final int slash = heightfieldDataset.lastIndexOf('/');
+		final String[] candidates = (slash > 0)
+				? new String[]{heightfieldDataset.substring(0, slash), heightfieldDataset}
+				: new String[]{heightfieldDataset};
+		for (final String path : candidates) {
+			final double[] f = n5.getAttribute(path, "downsamplingFactors", double[].class);
+			if (f != null) {
+				if (f.length < 3) {
+					throw new IllegalArgumentException(
+							"downsamplingFactors on " + path + " must have 3 elements, got " + f.length);
+				}
+				return f;
+			}
+		}
+		throw new IllegalArgumentException(
+				"no 'downsamplingFactors' attribute found on " + heightfieldDataset + " or its parent group");
 	}
 
 	/**
@@ -284,7 +311,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			final int[][] luts,
 			final float[] hf,
 			final long[] hfShape,
-			final int hfDownsample) {
+			final double[] factors) {
 
 		final N5Writer n5 = N5Util.createN5Writer(n5Path);
 		final RandomAccessibleInterval<UnsignedByteType> volume = N5Utils.open(n5, inDataset);
@@ -307,7 +334,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			final long y = dstCur.getLongPosition(1) + gridBlock[0][1];
 			final long z = dstCur.getLongPosition(2) + gridBlock[0][2];
 
-			dst.set(inTissue(z, x, y, hf, hfShape, hfDownsample) ? luts[(int) z][v] : v);
+			dst.set(inTissue(z, x, y, hf, hfShape, factors) ? luts[(int) z][v] : v);
 		}
 
 		N5Utils.saveNonEmptyBlock(out, n5, outDataset, gridBlock[2], new UnsignedByteType());

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensityHistogram.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensityHistogram.java
@@ -39,9 +39,13 @@ import net.imglib2.view.Views;
  * <p>
  * Only supports 8-bit data. Pass 1 (histogram collection) is parallelized over XY grid
  * blocks and reduced via {@link LayerHistogram#absorb}. Pass 2 applies the per-section
- * LUTs in a standard 3D block-grid Spark stage.
+ * LUTs in a standard 3D block-grid Spark stage. The heightfield is opened lazily in
+ * each executor task (never materialized on the driver) so very large fields (tens of
+ * thousands of pixels per side) don't cost driver memory.
  */
 public class MultiSemNormalizeLayerIntensityHistogram {
+
+	public static final int N_BINS = 256;
 
 	@SuppressWarnings({"FieldMayBeFinal", "unused", "FieldCanBeLocal"})
 	public static class Options extends AbstractOptions implements Serializable {
@@ -98,7 +102,6 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 
 		final long[] dims;
 		final int[] blockSize;
-		final float[] hf;
 		final long[] hfShape;
 		final double[] factors;
 
@@ -118,36 +121,35 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			dims = attrs.getDimensions();
 			blockSize = attrs.getBlockSize();
 
-			final RandomAccessibleInterval<FloatType> hfRai = N5Utils.open(n5, options.heightfieldDataset());
-			if (hfRai.numDimensions() != 2) {
-				throw new IllegalArgumentException("heightfield must be 2D, got " + hfRai.numDimensions() + "D");
+			final DatasetAttributes hfAttrs = n5.getDatasetAttributes(options.heightfieldDataset());
+			if (hfAttrs == null) {
+				throw new IllegalArgumentException("no attributes on " + options.heightfieldDataset());
 			}
-			hfShape = new long[]{hfRai.dimension(0), hfRai.dimension(1)};
-			hf = new float[(int)(hfShape[0] * hfShape[1])];
-			final Cursor<FloatType> c = Views.flatIterable(Views.zeroMin(hfRai)).cursor();
-			int i = 0;
-			while (c.hasNext()) {
-				hf[i++] = c.next().get();
+			final long[] hfDims = hfAttrs.getDimensions();
+			if (hfDims.length != 2) {
+				throw new IllegalArgumentException("heightfield must be 2D, got " + hfDims.length + "D");
 			}
+			hfShape = hfDims;
 
 			factors = readHeightfieldFactors(n5, options.heightfieldDataset());
-			System.out.println("Heightfield downsamplingFactors = [" +
-					factors[0] + ", " + factors[1] + ", " + factors[2] + "]");
+			System.out.println("Heightfield shape = [" + hfShape[0] + ", " + hfShape[1] + "]" +
+					", downsamplingFactors = [" + factors[0] + ", " + factors[1] + ", " + factors[2] + "]");
 		}
 
-		try (final N5Writer w = N5Util.createN5Writer(options.n5Path())) {
-			w.createDataset(options.n5DatasetOutput(), dims, blockSize, DataType.UINT8, new GzipCompression());
+		try (final N5Writer writer = N5Util.createN5Writer(options.n5Path())) {
+			writer.createDataset(options.n5DatasetOutput(), dims, blockSize, DataType.UINT8, new GzipCompression());
 		}
 
 		final int numZ = (int) dims[2];
 		final SparkConf conf = new SparkConf().setAppName("MultiSemNormalizeLayerIntensityHistogram");
 		try (final JavaSparkContext sc = new JavaSparkContext(conf)) {
 
-			final Broadcast<float[]> hfBc = sc.broadcast(hf);
 			final Broadcast<double[]> factorsBc = sc.broadcast(factors);
+			final Broadcast<long[]> hfShapeBc = sc.broadcast(hfShape);
 			final String n5Path = options.n5Path();
 			final String inDataset = options.n5DatasetInput();
 			final String outDataset = options.n5DatasetOutput();
+			final String hfDataset = options.heightfieldDataset();
 
 			// Pass 1: split XY into blocks, each task sweeps all z within its column
 			// and returns a per-section LayerHistogram of masked pixels in the block.
@@ -157,25 +159,84 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 					new int[]{blockSize[0], blockSize[1]});
 
 			final List<LayerHistogram> sectionHists = sc.parallelize(xyGrid)
-					.map(block -> columnHistograms(n5Path, inDataset, block, numZ, hfBc.value(), hfShape, factorsBc.value()))
+					.map(block -> columnHistograms(n5Path, inDataset, hfDataset, block, numZ,
+							hfShapeBc.value(), factorsBc.value()))
 					.reduce(MultiSemNormalizeLayerIntensityHistogram::mergeSectionHists);
 
-			final double[] refCdf = cdf256(sectionHists.get(options.refIndex()));
+			final double[] refCdf = extractCdf(sectionHists.get(options.refIndex()));
 			final int[][] luts = new int[numZ][];
 			for (int z = 0; z < numZ; z++) {
 				luts[z] = buildLut(sectionHists.get(z), refCdf);
 			}
 			System.out.println("Computed per-section LUTs against reference z=" + options.refIndex());
 
-			// Pass 2: 3D block grid, apply LUT[z] inside mask.
+			// Pass 2: 3D block grid, apply LUT[z] to every pixel. Layers with no in-tissue
+			// pixels have an identity LUT from buildLut so they pass through unchanged.
 			final Broadcast<int[][]> lutsBc = sc.broadcast(luts);
 			final List<long[][]> grid = Grid.create(dims, blockSize);
 			sc.parallelize(grid).foreach(block ->
-					processBlock(n5Path, inDataset, outDataset, block,
-								 lutsBc.value(), hfBc.value(), hfShape, factorsBc.value()));
+					processBlock(n5Path, inDataset, outDataset, block, lutsBc.value()));
 		}
 
 		System.out.println("wrote " + options.n5Path() + "/" + options.n5DatasetOutput());
+	}
+
+	/**
+	 * A small in-memory tile of the heightfield covering the XY extent of a single task,
+	 * built inside the executor by a lazy N5 read. Only the relevant N5 chunks are fetched.
+	 */
+	private static final class HfTile {
+		final float[] data;
+		final long hx0;
+		final long hy0;
+		final long width;
+
+		HfTile(final float[] data, final long hx0, final long hy0, final long width) {
+			this.data = data;
+			this.hx0 = hx0;
+			this.hy0 = hy0;
+			this.width = width;
+		}
+
+		boolean inTissue(final long z, final long x, final long y,
+						 final long[] hfShape, final double[] factors) {
+			final long hx = Math.min((long)(x / factors[0]), hfShape[0] - 1);
+			final long hy = Math.min((long)(y / factors[1]), hfShape[1] - 1);
+			final long lx = hx - hx0;
+			final long ly = hy - hy0;
+			final double val = data[(int)(ly * width + lx)] * factors[2];
+			return z < val;
+		}
+	}
+
+	private static HfTile loadHfTile(
+			final N5Reader n5,
+			final String hfDataset,
+			final long rawX0, final long rawY0,
+			final long rawX1, final long rawY1,
+			final long[] hfShape,
+			final double[] factors) {
+
+		final long hx0 = Math.min((long)(rawX0 / factors[0]), hfShape[0] - 1);
+		final long hy0 = Math.min((long)(rawY0 / factors[1]), hfShape[1] - 1);
+		final long hx1 = Math.min((long)(rawX1 / factors[0]), hfShape[0] - 1);
+		final long hy1 = Math.min((long)(rawY1 / factors[1]), hfShape[1] - 1);
+
+		final RandomAccessibleInterval<FloatType> hfRai = N5Utils.open(n5, hfDataset);
+		final RandomAccessibleInterval<FloatType> tile = Views.interval(
+				hfRai,
+				new long[]{hx0, hy0},
+				new long[]{hx1, hy1});
+
+		final long width = hx1 - hx0 + 1;
+		final long height = hy1 - hy0 + 1;
+		final float[] data = new float[(int)(width * height)];
+		final Cursor<FloatType> c = Views.flatIterable(Views.zeroMin(tile)).cursor();
+		int i = 0;
+		while (c.hasNext()) {
+			data[i++] = c.next().get();
+		}
+		return new HfTile(data, hx0, hy0, width);
 	}
 
 	/**
@@ -186,9 +247,9 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 	private static List<LayerHistogram> columnHistograms(
 			final String n5Path,
 			final String inDataset,
+			final String hfDataset,
 			final long[][] xyBlock,
 			final int numZ,
-			final float[] hf,
 			final long[] hfShape,
 			final double[] factors) {
 
@@ -200,9 +261,11 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 		final long x1 = x0 + xyBlock[1][0] - 1;
 		final long y1 = y0 + xyBlock[1][1] - 1;
 
+		final HfTile hfTile = loadHfTile(n5, hfDataset, x0, y0, x1, y1, hfShape, factors);
+
 		final List<LayerHistogram> result = new ArrayList<>(numZ);
 		for (int z = 0; z < numZ; z++) {
-			final long[] counts = new long[256];
+			final long[] counts = new long[N_BINS];
 			final RandomAccessibleInterval<UnsignedByteType> slice = Views.interval(
 					volume,
 					new long[]{x0, y0, z},
@@ -212,7 +275,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 				final int v = c.next().get();
 				final long x = c.getLongPosition(0);
 				final long y = c.getLongPosition(1);
-				if (inTissue(z, x, y, hf, hfShape, factors)) {
+				if (hfTile.inTissue(z, x, y, hfShape, factors)) {
 					counts[v]++;
 				}
 			}
@@ -228,15 +291,6 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			out.add(a.get(i).absorb(b.get(i)));
 		}
 		return out;
-	}
-
-	private static boolean inTissue(
-			final long z, final long x, final long y,
-			final float[] hf, final long[] hfShape, final double[] factors) {
-		final long hx = Math.min((long)(x / factors[0]), hfShape[0] - 1);
-		final long hy = Math.min((long)(y / factors[1]), hfShape[1] - 1);
-		final double val = hf[(int)(hy * hfShape[0] + hx)] * factors[2];
-		return z < val;
 	}
 
 	/**
@@ -268,17 +322,17 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 	 * the result is always aligned to integer intensity values 0..255. Returns a
 	 * uniform CDF if the histogram is empty.
 	 */
-	private static double[] cdf256(final LayerHistogram hist) {
-		final double[] cdf = new double[256];
+	private static double[] extractCdf(final LayerHistogram hist) {
+		final double[] cdf = new double[N_BINS];
 		final long total = hist.totalCount();
 		if (total == 0) {
-			for (int i = 0; i < 256; i++) cdf[i] = (i + 1) / 256.0;
+			for (int i = 0; i < N_BINS; i++) cdf[i] = (i + 1) / (double) N_BINS;
 			return cdf;
 		}
 		final long[] counts = hist.counts();
 		final int offset = hist.offset();
 		long acc = 0;
-		for (int v = 0; v < 256; v++) {
+		for (int v = 0; v < N_BINS; v++) {
 			final int idx = v + offset;
 			if (idx >= 0 && idx < counts.length) {
 				acc += counts[idx];
@@ -289,15 +343,15 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 	}
 
 	private static int[] buildLut(final LayerHistogram hist, final double[] refCdf) {
-		final int[] lut = new int[256];
+		final int[] lut = new int[N_BINS];
 		if (hist.totalCount() == 0) {
-			for (int i = 0; i < 256; i++) lut[i] = i;
+			for (int i = 0; i < N_BINS; i++) lut[i] = i;
 			return lut;
 		}
-		final double[] srcCdf = cdf256(hist);
+		final double[] srcCdf = extractCdf(hist);
 		int j = 0;
-		for (int i = 0; i < 256; i++) {
-			while (j < 255 && refCdf[j] < srcCdf[i]) j++;
+		for (int i = 0; i < N_BINS; i++) {
+			while (j < (N_BINS - 1) && refCdf[j] < srcCdf[i]) j++;
 			lut[i] = j;
 		}
 		return lut;
@@ -308,13 +362,12 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			final String inDataset,
 			final String outDataset,
 			final long[][] gridBlock,
-			final int[][] luts,
-			final float[] hf,
-			final long[] hfShape,
-			final double[] factors) {
+			final int[][] luts) {
 
 		final N5Writer n5 = N5Util.createN5Writer(n5Path);
 		final RandomAccessibleInterval<UnsignedByteType> volume = N5Utils.open(n5, inDataset);
+
+		final long z0 = gridBlock[0][2];
 
 		final FinalInterval blockInterval = Intervals.createMinSize(
 				gridBlock[0][0], gridBlock[0][1], gridBlock[0][2],
@@ -329,12 +382,8 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 		while (dstCur.hasNext()) {
 			final UnsignedByteType dst = dstCur.next();
 			final int v = srcCur.next().get();
-
-			final long x = dstCur.getLongPosition(0) + gridBlock[0][0];
-			final long y = dstCur.getLongPosition(1) + gridBlock[0][1];
-			final long z = dstCur.getLongPosition(2) + gridBlock[0][2];
-
-			dst.set(inTissue(z, x, y, hf, hfShape, factors) ? luts[(int) z][v] : v);
+			final long z = dstCur.getLongPosition(2) + z0;
+			dst.set(luts[(int) z][v]);
 		}
 
 		N5Utils.saveNonEmptyBlock(out, n5, outDataset, gridBlock[2], new UnsignedByteType());

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensityHistogram.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensityHistogram.java
@@ -1,0 +1,315 @@
+package org.janelia.saalfeldlab.hotknife;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import org.janelia.saalfeldlab.hotknife.SparkNormalizeLayerIntensityN5.LayerHistogram;
+import org.janelia.saalfeldlab.hotknife.util.Grid;
+import org.janelia.saalfeldlab.hotknife.util.N5Util;
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.GzipCompression;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+
+/**
+ * Per-section histogram matching within a tissue mask derived from a 2D height field.
+ * Mirrors the reference Python implementation: voxels with {@code z < heightfield(y, x)}
+ * are in-tissue; each section's in-tissue pixels are histogram-matched to those of a
+ * designated reference section. Out-of-tissue pixels pass through unchanged.
+ * <p>
+ * Only supports 8-bit data. Pass 1 (histogram collection) is parallelized over XY grid
+ * blocks and reduced via {@link LayerHistogram#absorb}. Pass 2 applies the per-section
+ * LUTs in a standard 3D block-grid Spark stage.
+ */
+public class MultiSemNormalizeLayerIntensityHistogram {
+
+	@SuppressWarnings({"FieldMayBeFinal", "unused", "FieldCanBeLocal"})
+	public static class Options extends AbstractOptions implements Serializable {
+
+		@Option(name = "--n5Path", required = true,
+				usage = "N5 path, e.g. /nrs/.../debug-costs.n5")
+		private String n5Path = null;
+
+		@Option(name = "--n5DatasetInput", required = true,
+				usage = "Input N5 dataset (3D UINT8), e.g. w61_s082/raw_tissue/s0")
+		private String n5DatasetInput = null;
+
+		@Option(name = "--n5DatasetOutput", required = true,
+				usage = "Output N5 dataset, e.g. w61_s082/michal-processed-hf/s0")
+		private String n5DatasetOutput = null;
+
+		@Option(name = "--heightfieldDataset", required = true,
+				usage = "2D height field dataset (FloatType), e.g. w61_s082/heightfield_1/s1/max")
+		private String heightfieldDataset = null;
+
+		@Option(name = "--hfDownsample",
+				usage = "XY downsample factor of the heightfield relative to the raw (default: 2)")
+		private int hfDownsample = 2;
+
+		@Option(name = "--refIndex",
+				usage = "Z index of the reference section (default: 5)")
+		private int refIndex = 5;
+
+		public Options(final String[] args) {
+			final CmdLineParser parser = new CmdLineParser(this);
+			try {
+				parser.parseArgument(args);
+				parsedSuccessfully = true;
+			} catch (final Exception e) {
+				e.printStackTrace(System.err);
+				parser.printUsage(System.err);
+			}
+		}
+
+		public String n5Path() { return n5Path; }
+		public String n5DatasetInput() { return n5DatasetInput; }
+		public String n5DatasetOutput() { return n5DatasetOutput; }
+		public String heightfieldDataset() { return heightfieldDataset; }
+		public int hfDownsample() { return hfDownsample; }
+		public int refIndex() { return refIndex; }
+	}
+
+	public static void main(final String... args) throws IOException, InterruptedException, ExecutionException {
+		final Options options = new Options(args);
+		if (!options.parsedSuccessfully) {
+			throw new IllegalArgumentException("Options were not parsed successfully");
+		}
+		run(options);
+	}
+
+	private static void run(final Options options) {
+
+		final long[] dims;
+		final int[] blockSize;
+		final float[] hf;
+		final long[] hfShape;
+
+		try (final N5Reader n5 = N5Util.createN5Reader(options.n5Path())) {
+
+			if (n5.exists(options.n5DatasetOutput())) {
+				throw new IllegalArgumentException("output dataset already exists: " + options.n5DatasetOutput());
+			}
+
+			final DatasetAttributes attrs = n5.getDatasetAttributes(options.n5DatasetInput());
+			if (attrs == null) {
+				throw new IllegalArgumentException("no attributes on " + options.n5DatasetInput());
+			}
+			if (attrs.getDataType() != DataType.UINT8) {
+				throw new IllegalArgumentException("only 8-bit supported, found: " + attrs.getDataType());
+			}
+			dims = attrs.getDimensions();
+			blockSize = attrs.getBlockSize();
+
+			final RandomAccessibleInterval<FloatType> hfRai = N5Utils.open(n5, options.heightfieldDataset());
+			if (hfRai.numDimensions() != 2) {
+				throw new IllegalArgumentException("heightfield must be 2D, got " + hfRai.numDimensions() + "D");
+			}
+			hfShape = new long[]{hfRai.dimension(0), hfRai.dimension(1)};
+			hf = new float[(int)(hfShape[0] * hfShape[1])];
+			final Cursor<FloatType> c = Views.flatIterable(Views.zeroMin(hfRai)).cursor();
+			int i = 0;
+			while (c.hasNext()) {
+				hf[i++] = c.next().get();
+			}
+		}
+
+		try (final N5Writer w = N5Util.createN5Writer(options.n5Path())) {
+			w.createDataset(options.n5DatasetOutput(), dims, blockSize, DataType.UINT8, new GzipCompression());
+		}
+
+		final int numZ = (int) dims[2];
+		final SparkConf conf = new SparkConf().setAppName("MultiSemNormalizeLayerIntensityHistogram");
+		try (final JavaSparkContext sc = new JavaSparkContext(conf)) {
+
+			final Broadcast<float[]> hfBc = sc.broadcast(hf);
+			final int hfDs = options.hfDownsample();
+			final String n5Path = options.n5Path();
+			final String inDataset = options.n5DatasetInput();
+			final String outDataset = options.n5DatasetOutput();
+
+			// Pass 1: split XY into blocks, each task sweeps all z within its column
+			// and returns a per-section LayerHistogram of masked pixels in the block.
+			// Reduce element-wise via absorb to get per-section totals over the full XY plane.
+			final List<long[][]> xyGrid = Grid.create(
+					new long[]{dims[0], dims[1]},
+					new int[]{blockSize[0], blockSize[1]});
+
+			final List<LayerHistogram> sectionHists = sc.parallelize(xyGrid)
+					.map(block -> columnHistograms(n5Path, inDataset, block, numZ, hfBc.value(), hfShape, hfDs))
+					.reduce(MultiSemNormalizeLayerIntensityHistogram::mergeSectionHists);
+
+			final double[] refCdf = cdf256(sectionHists.get(options.refIndex()));
+			final int[][] luts = new int[numZ][];
+			for (int z = 0; z < numZ; z++) {
+				luts[z] = buildLut(sectionHists.get(z), refCdf);
+			}
+			System.out.println("Computed per-section LUTs against reference z=" + options.refIndex());
+
+			// Pass 2: 3D block grid, apply LUT[z] inside mask.
+			final Broadcast<int[][]> lutsBc = sc.broadcast(luts);
+			final List<long[][]> grid = Grid.create(dims, blockSize);
+			sc.parallelize(grid).foreach(block ->
+					processBlock(n5Path, inDataset, outDataset, block,
+								 lutsBc.value(), hfBc.value(), hfShape, hfDs));
+		}
+
+		System.out.println("wrote " + options.n5Path() + "/" + options.n5DatasetOutput());
+	}
+
+	/**
+	 * For a single XY column, return one {@link LayerHistogram} per section containing
+	 * the intensity counts of in-tissue pixels within that column. Always constructed
+	 * with offset=0 and length 256 so {@link LayerHistogram#absorb} stays 8-bit-aligned.
+	 */
+	private static List<LayerHistogram> columnHistograms(
+			final String n5Path,
+			final String inDataset,
+			final long[][] xyBlock,
+			final int numZ,
+			final float[] hf,
+			final long[] hfShape,
+			final int hfDownsample) {
+
+		final N5Reader n5 = N5Util.createN5Reader(n5Path);
+		final RandomAccessibleInterval<UnsignedByteType> volume = N5Utils.open(n5, inDataset);
+
+		final long x0 = xyBlock[0][0];
+		final long y0 = xyBlock[0][1];
+		final long x1 = x0 + xyBlock[1][0] - 1;
+		final long y1 = y0 + xyBlock[1][1] - 1;
+
+		final List<LayerHistogram> result = new ArrayList<>(numZ);
+		for (int z = 0; z < numZ; z++) {
+			final long[] counts = new long[256];
+			final RandomAccessibleInterval<UnsignedByteType> slice = Views.interval(
+					volume,
+					new long[]{x0, y0, z},
+					new long[]{x1, y1, z});
+			final Cursor<UnsignedByteType> c = Views.flatIterable(slice).localizingCursor();
+			while (c.hasNext()) {
+				final int v = c.next().get();
+				final long x = c.getLongPosition(0);
+				final long y = c.getLongPosition(1);
+				if (inTissue(z, x, y, hf, hfShape, hfDownsample)) {
+					counts[v]++;
+				}
+			}
+			result.add(LayerHistogram.fromCounts(counts, 0, 0.0));
+		}
+		return result;
+	}
+
+	private static List<LayerHistogram> mergeSectionHists(
+			final List<LayerHistogram> a, final List<LayerHistogram> b) {
+		final List<LayerHistogram> out = new ArrayList<>(a.size());
+		for (int i = 0; i < a.size(); i++) {
+			out.add(a.get(i).absorb(b.get(i)));
+		}
+		return out;
+	}
+
+	private static boolean inTissue(
+			final long z, final long x, final long y,
+			final float[] hf, final long[] hfShape, final int hfDownsample) {
+		final long hx = Math.min(x / hfDownsample, hfShape[0] - 1);
+		final long hy = Math.min(y / hfDownsample, hfShape[1] - 1);
+		return z < hf[(int)(hy * hfShape[0] + hx)];
+	}
+
+	/**
+	 * Extract a 256-entry CDF from a LayerHistogram. Respects the internal offset so
+	 * the result is always aligned to integer intensity values 0..255. Returns a
+	 * uniform CDF if the histogram is empty.
+	 */
+	private static double[] cdf256(final LayerHistogram hist) {
+		final double[] cdf = new double[256];
+		final long total = hist.totalCount();
+		if (total == 0) {
+			for (int i = 0; i < 256; i++) cdf[i] = (i + 1) / 256.0;
+			return cdf;
+		}
+		final long[] counts = hist.counts();
+		final int offset = hist.offset();
+		long acc = 0;
+		for (int v = 0; v < 256; v++) {
+			final int idx = v + offset;
+			if (idx >= 0 && idx < counts.length) {
+				acc += counts[idx];
+			}
+			cdf[v] = (double) acc / total;
+		}
+		return cdf;
+	}
+
+	private static int[] buildLut(final LayerHistogram hist, final double[] refCdf) {
+		final int[] lut = new int[256];
+		if (hist.totalCount() == 0) {
+			for (int i = 0; i < 256; i++) lut[i] = i;
+			return lut;
+		}
+		final double[] srcCdf = cdf256(hist);
+		int j = 0;
+		for (int i = 0; i < 256; i++) {
+			while (j < 255 && refCdf[j] < srcCdf[i]) j++;
+			lut[i] = j;
+		}
+		return lut;
+	}
+
+	private static void processBlock(
+			final String n5Path,
+			final String inDataset,
+			final String outDataset,
+			final long[][] gridBlock,
+			final int[][] luts,
+			final float[] hf,
+			final long[] hfShape,
+			final int hfDownsample) {
+
+		final N5Writer n5 = N5Util.createN5Writer(n5Path);
+		final RandomAccessibleInterval<UnsignedByteType> volume = N5Utils.open(n5, inDataset);
+
+		final FinalInterval blockInterval = Intervals.createMinSize(
+				gridBlock[0][0], gridBlock[0][1], gridBlock[0][2],
+				gridBlock[1][0], gridBlock[1][1], gridBlock[1][2]);
+
+		final long[] blockDims = new long[]{gridBlock[1][0], gridBlock[1][1], gridBlock[1][2]};
+		final Img<UnsignedByteType> out = ArrayImgs.unsignedBytes(blockDims);
+
+		final Cursor<UnsignedByteType> srcCur = Views.flatIterable(Views.interval(volume, blockInterval)).cursor();
+		final Cursor<UnsignedByteType> dstCur = Views.flatIterable(out).localizingCursor();
+
+		while (dstCur.hasNext()) {
+			final UnsignedByteType dst = dstCur.next();
+			final int v = srcCur.next().get();
+
+			final long x = dstCur.getLongPosition(0) + gridBlock[0][0];
+			final long y = dstCur.getLongPosition(1) + gridBlock[0][1];
+			final long z = dstCur.getLongPosition(2) + gridBlock[0][2];
+
+			dst.set(inTissue(z, x, y, hf, hfShape, hfDownsample) ? luts[(int) z][v] : v);
+		}
+
+		N5Utils.saveNonEmptyBlock(out, n5, outDataset, gridBlock[2], new UnsignedByteType());
+	}
+}

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensityHistogram.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/MultiSemNormalizeLayerIntensityHistogram.java
@@ -12,6 +12,7 @@ import org.apache.spark.broadcast.Broadcast;
 import org.janelia.saalfeldlab.hotknife.SparkNormalizeLayerIntensityN5.LayerHistogram;
 import org.janelia.saalfeldlab.hotknife.util.Grid;
 import org.janelia.saalfeldlab.hotknife.util.N5Util;
+import org.janelia.saalfeldlab.hotknife.util.Transform;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.GzipCompression;
@@ -27,6 +28,7 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.DoubleType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Intervals;
 import net.imglib2.view.Views;
@@ -39,9 +41,7 @@ import net.imglib2.view.Views;
  * <p>
  * Only supports 8-bit data. Pass 1 (histogram collection) is parallelized over XY grid
  * blocks and reduced via {@link LayerHistogram#absorb}. Pass 2 applies the per-section
- * LUTs in a standard 3D block-grid Spark stage. The heightfield is opened lazily in
- * each executor task (never materialized on the driver) so very large fields (tens of
- * thousands of pixels per side) don't cost driver memory.
+ * LUTs in a standard 3D block-grid Spark stage.
  */
 public class MultiSemNormalizeLayerIntensityHistogram {
 
@@ -69,7 +69,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 		private String heightfieldDataset = null;
 
 		@Option(name = "--refIndex",
-				usage = "Z index of the reference section (default: 5)")
+				usage = "Z index of the reference section used to equalize histograms to (default: 5)")
 		private int refIndex = 5;
 
 		public Options(final String[] args) {
@@ -102,11 +102,10 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 
 		final long[] dims;
 		final int[] blockSize;
-		final long[] hfShape;
 		final double[] factors;
 
 		try (final N5Reader n5 = N5Util.createN5Reader(options.n5Path())) {
-
+			// Read heightfield factors and make sure the full data setup is valid
 			if (n5.exists(options.n5DatasetOutput())) {
 				throw new IllegalArgumentException("output dataset already exists: " + options.n5DatasetOutput());
 			}
@@ -125,15 +124,13 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			if (hfAttrs == null) {
 				throw new IllegalArgumentException("no attributes on " + options.heightfieldDataset());
 			}
-			final long[] hfDims = hfAttrs.getDimensions();
-			if (hfDims.length != 2) {
-				throw new IllegalArgumentException("heightfield must be 2D, got " + hfDims.length + "D");
+			if (hfAttrs.getDimensions().length != 2) {
+				throw new IllegalArgumentException("heightfield must be 2D, got " + hfAttrs.getDimensions().length + "D");
 			}
-			hfShape = hfDims;
 
 			factors = readHeightfieldFactors(n5, options.heightfieldDataset());
-			System.out.println("Heightfield shape = [" + hfShape[0] + ", " + hfShape[1] + "]" +
-					", downsamplingFactors = [" + factors[0] + ", " + factors[1] + ", " + factors[2] + "]");
+			System.out.println("Heightfield downsamplingFactors = [" +
+					factors[0] + ", " + factors[1] + ", " + factors[2] + "]");
 		}
 
 		try (final N5Writer writer = N5Util.createN5Writer(options.n5Path())) {
@@ -145,7 +142,6 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 		try (final JavaSparkContext sc = new JavaSparkContext(conf)) {
 
 			final Broadcast<double[]> factorsBc = sc.broadcast(factors);
-			final Broadcast<long[]> hfShapeBc = sc.broadcast(hfShape);
 			final String n5Path = options.n5Path();
 			final String inDataset = options.n5DatasetInput();
 			final String outDataset = options.n5DatasetOutput();
@@ -159,8 +155,7 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 					new int[]{blockSize[0], blockSize[1]});
 
 			final List<LayerHistogram> sectionHists = sc.parallelize(xyGrid)
-					.map(block -> columnHistograms(n5Path, inDataset, hfDataset, block, numZ,
-							hfShapeBc.value(), factorsBc.value()))
+					.map(block -> columnHistograms(n5Path, inDataset, hfDataset, block, numZ, factorsBc.value()))
 					.reduce(MultiSemNormalizeLayerIntensityHistogram::mergeSectionHists);
 
 			final double[] refCdf = extractCdf(sectionHists.get(options.refIndex()));
@@ -182,67 +177,10 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 	}
 
 	/**
-	 * A small in-memory tile of the heightfield covering the XY extent of a single task,
-	 * built inside the executor by a lazy N5 read. Only the relevant N5 chunks are fetched.
-	 */
-	private static final class HfTile {
-		final float[] data;
-		final long hx0;
-		final long hy0;
-		final long width;
-
-		HfTile(final float[] data, final long hx0, final long hy0, final long width) {
-			this.data = data;
-			this.hx0 = hx0;
-			this.hy0 = hy0;
-			this.width = width;
-		}
-
-		boolean inTissue(final long z, final long x, final long y,
-						 final long[] hfShape, final double[] factors) {
-			final long hx = Math.min((long)(x / factors[0]), hfShape[0] - 1);
-			final long hy = Math.min((long)(y / factors[1]), hfShape[1] - 1);
-			final long lx = hx - hx0;
-			final long ly = hy - hy0;
-			final double val = data[(int)(ly * width + lx)] * factors[2];
-			return z < val;
-		}
-	}
-
-	private static HfTile loadHfTile(
-			final N5Reader n5,
-			final String hfDataset,
-			final long rawX0, final long rawY0,
-			final long rawX1, final long rawY1,
-			final long[] hfShape,
-			final double[] factors) {
-
-		final long hx0 = Math.min((long)(rawX0 / factors[0]), hfShape[0] - 1);
-		final long hy0 = Math.min((long)(rawY0 / factors[1]), hfShape[1] - 1);
-		final long hx1 = Math.min((long)(rawX1 / factors[0]), hfShape[0] - 1);
-		final long hy1 = Math.min((long)(rawY1 / factors[1]), hfShape[1] - 1);
-
-		final RandomAccessibleInterval<FloatType> hfRai = N5Utils.open(n5, hfDataset);
-		final RandomAccessibleInterval<FloatType> tile = Views.interval(
-				hfRai,
-				new long[]{hx0, hy0},
-				new long[]{hx1, hy1});
-
-		final long width = hx1 - hx0 + 1;
-		final long height = hy1 - hy0 + 1;
-		final float[] data = new float[(int)(width * height)];
-		final Cursor<FloatType> c = Views.flatIterable(Views.zeroMin(tile)).cursor();
-		int i = 0;
-		while (c.hasNext()) {
-			data[i++] = c.next().get();
-		}
-		return new HfTile(data, hx0, hy0, width);
-	}
-
-	/**
 	 * For a single XY column, return one {@link LayerHistogram} per section containing
-	 * the intensity counts of in-tissue pixels within that column. Always constructed
-	 * with offset=0 and length 256 so {@link LayerHistogram#absorb} stays 8-bit-aligned.
+	 * the intensity counts of in-tissue pixels within that column.
+	 * <p>
+	 * The heightfield is opened lazily and rescaled to raw XY coordinates.
 	 */
 	private static List<LayerHistogram> columnHistograms(
 			final String n5Path,
@@ -250,32 +188,36 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 			final String hfDataset,
 			final long[][] xyBlock,
 			final int numZ,
-			final long[] hfShape,
 			final double[] factors) {
 
 		final N5Reader n5 = N5Util.createN5Reader(n5Path);
 		final RandomAccessibleInterval<UnsignedByteType> volume = N5Utils.open(n5, inDataset);
+		final RandomAccessibleInterval<FloatType> hfRai = N5Utils.open(n5, hfDataset);
 
 		final long x0 = xyBlock[0][0];
 		final long y0 = xyBlock[0][1];
 		final long x1 = x0 + xyBlock[1][0] - 1;
 		final long y1 = y0 + xyBlock[1][1] - 1;
 
-		final HfTile hfTile = loadHfTile(n5, hfDataset, x0, y0, x1, y1, hfShape, factors);
+		// Heightfield rescaled to raw XY coordinates (positions) and raw Z (values).
+		// Accessing this at integer raw (x, y) gives back the tissue boundary z directly.
+		final RandomAccessibleInterval<DoubleType> hfAtRawScale = Views.interval(
+				Views.raster(Transform.scaleAndShiftHeightFieldAndValues(hfRai, factors)),
+				new long[]{x0, y0},
+				new long[]{x1, y1});
 
 		final List<LayerHistogram> result = new ArrayList<>(numZ);
 		for (int z = 0; z < numZ; z++) {
 			final long[] counts = new long[N_BINS];
 			final RandomAccessibleInterval<UnsignedByteType> slice = Views.interval(
-					volume,
-					new long[]{x0, y0, z},
-					new long[]{x1, y1, z});
-			final Cursor<UnsignedByteType> c = Views.flatIterable(slice).localizingCursor();
-			while (c.hasNext()) {
-				final int v = c.next().get();
-				final long x = c.getLongPosition(0);
-				final long y = c.getLongPosition(1);
-				if (hfTile.inTissue(z, x, y, hfShape, factors)) {
+					Views.hyperSlice(volume, 2, z),
+					new long[]{x0, y0},
+					new long[]{x1, y1});
+			final Cursor<UnsignedByteType> srcCursor = Views.flatIterable(slice).cursor();
+			final Cursor<DoubleType> hfCursor = Views.flatIterable(hfAtRawScale).cursor();
+			while (srcCursor.hasNext()) {
+				final int v = srcCursor.next().get();
+				if (z < hfCursor.next().get()) {
 					counts[v]++;
 				}
 			}
@@ -342,6 +284,10 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 		return cdf;
 	}
 
+	/**
+	 * Build a LUT mapping source intensity values to reference intensity values based on
+	 * the source histogram and reference CDF. Uses a standard histogram matching approach.
+	 */
 	private static int[] buildLut(final LayerHistogram hist, final double[] refCdf) {
 		final int[] lut = new int[N_BINS];
 		if (hist.totalCount() == 0) {
@@ -357,6 +303,9 @@ public class MultiSemNormalizeLayerIntensityHistogram {
 		return lut;
 	}
 
+	/**
+	 * Apply the per-section LUTs to a single 3D block and write the result to the output dataset.
+	 */
 	private static void processBlock(
 			final String n5Path,
 			final String inDataset,

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
@@ -26,7 +26,6 @@ import org.kohsuke.args4j.Option;
 import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converters;
-import net.imglib2.img.Img;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
@@ -149,40 +148,48 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 	}
 
 	protected void run() throws IOException {
-		// Compute transformations based on downsampled input
-		final List<AffineModel1D> transformations;
+		// Read downscaled dataset attributes for grid creation and z-dimension validation
+		final DatasetAttributes downscaledAttributes;
 		try (final N5Reader n5reader = N5Util.createN5Reader(options.n5Path)) {
-			final Img<T> downScaledImg = N5Utils.open(n5reader, downScaledInputDataset);
-			transformations = computeTransformations(downScaledImg);
+			downscaledAttributes = n5reader.getDatasetAttributes(downScaledInputDataset);
 		}
 
-		if (transformations.size() != attributes.getDimensions()[2]) {
-			throw new IllegalArgumentException("Number of transformations does not match number of layers: " + transformations.size()
-					+ " vs. " + attributes.getDimensions()[2] + ". Is the z-dimension downsampled?");
+		final int nLayers = (int) downscaledAttributes.getDimensions()[2];
+		if (nLayers != attributes.getDimensions()[2]) {
+			throw new IllegalArgumentException("Number of downscaled layers does not match full-scale layers: "
+													   + nLayers + " vs. " + attributes.getDimensions()[2] + ". Is the z-dimension downsampled?");
 		}
 
-		// Apply transformations to full scale input and save to output dataset
+		final SparkConf conf = new SparkConf().setAppName("SparkNormalizeLayerIntensityN5");
+		try (final JavaSparkContext sparkContext = new JavaSparkContext(conf)) {
+			final List<AffineModel1D> transformations = computeTransformations(sparkContext, downscaledAttributes);
+			applyAndWrite(sparkContext, transformations);
+		}
+	}
+
+	/**
+	 * Apply transformations to the full-scale input, write the output dataset,
+	 * optionally downsample, and transfer base attributes.
+	 */
+	private void applyAndWrite(final JavaSparkContext sparkContext, final List<AffineModel1D> transformations) throws IOException {
+		// Create output dataset
 		try (final N5Writer n5Writer = N5Util.createN5Writer(options.n5Path)) {
 			n5Writer.createDataset(fullScaleOutputDataset, attributes);
 		}
 
 		final List<long[][]> grid = Grid.create(attributes.getDimensions(), attributes.getBlockSize());
-		final SparkConf conf = new SparkConf().setAppName("SparkNormalizeLayerIntensityN5");
 
-		try (final JavaSparkContext sparkContext = new JavaSparkContext(conf)) {
+		final JavaRDD<long[][]> parallelizedGrid = sparkContext.parallelize(grid);
+		final Broadcast<List<? extends AbstractAffineModel1D<?>>> transformationsBroadcast = sparkContext.broadcast(transformations);
+		parallelizedGrid.foreach(gridBlock -> saveFullScaleBlock(transformationsBroadcast.value(), gridBlock));
 
-			final JavaRDD<long[][]> parallelizedGrid = sparkContext.parallelize(grid);
-			final Broadcast<List<? extends AbstractAffineModel1D<?>>> transformationsBroadcast = sparkContext.broadcast(transformations);
-			parallelizedGrid.foreach(gridBlock -> saveFullScaleBlock(transformationsBroadcast.value(), gridBlock));
-
-			final int[] downsampleFactors = parseCSIntArray(options.factors);
-			if (downsampleFactors != null) {
-				downsampleScalePyramid(sparkContext,
-									   new N5PathSupplier(options.n5Path),
-									   fullScaleOutputDataset,
-									   options.n5DatasetOutput,
-									   downsampleFactors);
-			}
+		final int[] downsampleFactors = parseCSIntArray(options.factors);
+		if (downsampleFactors != null) {
+			downsampleScalePyramid(sparkContext,
+								   new N5PathSupplier(options.n5Path),
+								   fullScaleOutputDataset,
+								   options.n5DatasetOutput,
+								   downsampleFactors);
 		}
 
 		// Copy attributes and rebuild 'scales' attribute
@@ -193,13 +200,16 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 
 
 	/**
-	 * Compute the intensity transformations for each layer.
+	 * Compute the intensity transformations for each layer using Spark for parallelization.
 	 * Subclasses implement different strategies for computing these transformations.
 	 *
-	 * @param rai the downsampled input image
+	 * @param sparkContext the Spark context for parallelization
+	 * @param downscaledAttributes attributes of the downscaled input dataset
 	 * @return list of affine models, one per layer
 	 */
-	protected abstract List<AffineModel1D> computeTransformations(final RandomAccessibleInterval<T> rai);
+	protected abstract List<AffineModel1D> computeTransformations(
+			final JavaSparkContext sparkContext,
+			final DatasetAttributes downscaledAttributes);
 
 	private RandomAccessibleInterval<T> applyTransformations(
 			final RandomAccessibleInterval<T> sourceRaw,
@@ -262,7 +272,7 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 	 * rank and accumulated statistics on demand, applying a cutoff to discard outliers.
 	 * Can be merged with other instances for parallel computation.
 	 */
-	protected static class LayerHistogram {
+	protected static class LayerHistogram implements Serializable {
 		private final long[] counts;
 		private final int offset;  // value v is stored at index v + offset
 		private final long totalCount;
@@ -273,6 +283,10 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 			this.offset = offset;
 			this.totalCount = totalCount;
 			this.cutoff = cutoff;
+		}
+
+		public long totalCount() {
+			return totalCount;
 		}
 
 		/**
@@ -300,7 +314,7 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 			return new LayerHistogram(counts, offset, values.size(), cutoff);
 		}
 
-		public LayerHistogram merge(final LayerHistogram other) {
+		public LayerHistogram absorb(final LayerHistogram other) {
 			if (totalCount == 0) return other;
 			if (other.totalCount == 0) return this;
 

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
@@ -323,6 +323,28 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 		}
 
 		/**
+		 * Build a histogram from a pre-computed count array. Value {@code v} is read from
+		 * {@code counts[v + offset]}. The array is retained by reference; do not mutate
+		 * after handing it over.
+		 */
+		public static LayerHistogram fromCounts(final long[] counts, final int offset, final double cutoff) {
+			long total = 0;
+			for (final long c : counts) {
+				total += c;
+			}
+			return new LayerHistogram(counts, offset, total, cutoff);
+		}
+
+		/** Internal bin counts. Aligned so value {@code v} is at {@code counts()[v + offset()]}. Do not mutate. */
+		public long[] counts() {
+			return counts;
+		}
+
+		public int offset() {
+			return offset;
+		}
+
+		/**
 		 * Build a histogram from a list of integer-valued doubles.
 		 */
 		public static LayerHistogram from(final List<Double> values, final double cutoff) {

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
@@ -306,9 +306,9 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 	 * Can be merged with other instances for parallel computation.
 	 */
 	protected static class LayerHistogram implements Serializable {
-		private final long[] counts;
-		private final int offset;  // value v is stored at index v + offset
-		private final long totalCount;
+		private long[] counts;
+		private int offset;  // value v is stored at index v + offset
+		private long totalCount;
 		private final double cutoff;
 
 		private LayerHistogram(final long[] counts, final int offset, final long totalCount, final double cutoff) {
@@ -370,9 +370,20 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 		}
 
 		public LayerHistogram absorb(final LayerHistogram other) {
-			if (totalCount == 0) return other;
-			if (other.totalCount == 0) return this;
+			// No others to absorb
+			if (other.totalCount == 0) {
+				return this;
+			}
 
+			// This is empty, clone the other
+			if (totalCount == 0) {
+				this.counts = other.counts.clone();
+				this.offset = other.offset;
+				this.totalCount = other.totalCount;
+				return this;
+			}
+
+			// Compute new min/max/offset values for the combined histogram
 			final int thisMin = -offset;
 			final int thisMax = counts.length - 1 - offset;
 			final int otherMin = -other.offset;
@@ -381,16 +392,28 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 			final int newMin = Math.min(thisMin, otherMin);
 			final int newMax = Math.max(thisMax, otherMax);
 			final int newOffset = -newMin;
-			final long[] newCounts = new long[newMax - newMin + 1];
+			final int newLen = newMax - newMin + 1;
 
-			for (int i = 0; i < counts.length; i++) {
-				newCounts[i - offset + newOffset] += counts[i];
+			// Allocate enough space for the combined histogram and copy this's values
+			final long[] newCounts;
+			if (newLen == counts.length && newOffset == offset) {
+				newCounts = counts;
+			} else {
+				newCounts = new long[newLen];
+				for (int i = 0; i < counts.length; i++) {
+					newCounts[i - offset + newOffset] += counts[i];
+				}
 			}
+
+			// Update the combined histogram with the other's values
 			for (int i = 0; i < other.counts.length; i++) {
 				newCounts[i - other.offset + newOffset] += other.counts[i];
 			}
 
-			return new LayerHistogram(newCounts, newOffset, totalCount + other.totalCount, cutoff);
+			this.counts = newCounts;
+			this.offset = newOffset;
+			this.totalCount = totalCount + other.totalCount;
+			return this;
 		}
 
 		public double median() {

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
@@ -3,7 +3,6 @@ package org.janelia.saalfeldlab.hotknife;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -259,48 +258,151 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 
 
 	/**
-	 * Helper class to hold the median, mean, min and max (discarding some cutoff pixels on either side) of a layer.
+	 * Histogram-based statistics for a layer. Holds an integer histogram and computes
+	 * rank and accumulated statistics on demand, applying a cutoff to discard outliers.
+	 * Can be merged with other instances for parallel computation.
 	 */
-	protected static class LayerStats {
-		public final double median;
-		public final double mean;
-		public final double std;
-		public final double min;
-		public final double max;
+	protected static class LayerHistogram {
+		private final long[] counts;
+		private final int offset;  // value v is stored at index v + offset
+		private final long totalCount;
+		private final double cutoff;
 
-		private LayerStats(
-				final double median,
-				final double mean,
-				final double std,
-				final double min,
-				final double max
-		) {
-			this.median = median;
-			this.mean = mean;
-			this.std = std;
-			this.min = min;
-			this.max = max;
+		private LayerHistogram(final long[] counts, final int offset, final long totalCount, final double cutoff) {
+			this.counts = counts;
+			this.offset = offset;
+			this.totalCount = totalCount;
+			this.cutoff = cutoff;
 		}
 
-		public static LayerStats from(final List<Double> pixelList, final double cutoff) {
-			// Convert to sorted array for rank statistics
-			final double[] pixels = pixelList.stream().mapToDouble(Double::doubleValue).sorted().toArray();
+		/**
+		 * Build a histogram from a list of integer-valued doubles.
+		 */
+		public static LayerHistogram from(final List<Double> values, final double cutoff) {
+			if (values.isEmpty()) {
+				return new LayerHistogram(new long[0], 0, 0, cutoff);
+			}
 
-			// Compute histogram clipping bounds
-			final int start = (int) Math.round(pixels.length * cutoff);
-			final int end = pixels.length - start;
+			int minVal = Integer.MAX_VALUE;
+			int maxVal = Integer.MIN_VALUE;
+			for (final double v : values) {
+				final int iv = (int) v;
+				if (iv < minVal) minVal = iv;
+				if (iv > maxVal) maxVal = iv;
+			}
 
-			final double median = pixels[pixels.length / 2];
-			final double min = pixels[start];
-			final double max = pixels[end - 1];
+			final int offset = -minVal;
+			final long[] counts = new long[maxVal - minVal + 1];
+			for (final double v : values) {
+				counts[(int) v + offset]++;
+			}
 
-			// Compute accumulated statistics over clipped pixels
-			final double mean = Arrays.stream(pixels, start, end).average().orElse(0.0);
-			final double std = Math.sqrt(Arrays.stream(pixels, start, end)
-					.map(v -> (v - mean) * (v - mean))
-					.average().orElse(0.0));
+			return new LayerHistogram(counts, offset, values.size(), cutoff);
+		}
 
-			return new LayerStats(median, mean, std, min, max);
+		public LayerHistogram merge(final LayerHistogram other) {
+			if (totalCount == 0) return other;
+			if (other.totalCount == 0) return this;
+
+			final int thisMin = -offset;
+			final int thisMax = counts.length - 1 - offset;
+			final int otherMin = -other.offset;
+			final int otherMax = other.counts.length - 1 - other.offset;
+
+			final int newMin = Math.min(thisMin, otherMin);
+			final int newMax = Math.max(thisMax, otherMax);
+			final int newOffset = -newMin;
+			final long[] newCounts = new long[newMax - newMin + 1];
+
+			for (int i = 0; i < counts.length; i++) {
+				newCounts[i - offset + newOffset] += counts[i];
+			}
+			for (int i = 0; i < other.counts.length; i++) {
+				newCounts[i - other.offset + newOffset] += other.counts[i];
+			}
+
+			return new LayerHistogram(newCounts, newOffset, totalCount + other.totalCount, cutoff);
+		}
+
+		public double median() {
+			return valueAtRank(totalCount / 2);
+		}
+
+		public double min() {
+			final long start = Math.round(totalCount * cutoff);
+			return valueAtRank(start);
+		}
+
+		public double max() {
+			final long start = Math.round(totalCount * cutoff);
+			final long end = totalCount - start;
+			return valueAtRank(end - 1);
+		}
+
+		public double mean() {
+			final long start = Math.round(totalCount * cutoff);
+			final long end = totalCount - start;
+
+			double sum = 0;
+			long cumulative = 0;
+			long clippedCount = 0;
+
+			for (int i = 0; i < counts.length; i++) {
+				if (counts[i] == 0) continue;
+				final long prevCumulative = cumulative;
+				cumulative += counts[i];
+				final double value = i - offset;
+
+				// How many of this bin's entries fall within [start, end)?
+				final long binStart = Math.max(start, prevCumulative);
+				final long binEnd = Math.min(end, cumulative);
+				if (binEnd > binStart) {
+					final long n = binEnd - binStart;
+					sum += value * n;
+					clippedCount += n;
+				}
+			}
+
+			return clippedCount > 0 ? sum / clippedCount : 0.0;
+		}
+
+		public double std() {
+			final double m = mean();
+			final long start = Math.round(totalCount * cutoff);
+			final long end = totalCount - start;
+
+			double sumSqDiff = 0;
+			long cumulative = 0;
+			long clippedCount = 0;
+
+			for (int i = 0; i < counts.length; i++) {
+				if (counts[i] == 0) continue;
+				final long prevCumulative = cumulative;
+				cumulative += counts[i];
+				final double value = i - offset;
+
+				final long binStart = Math.max(start, prevCumulative);
+				final long binEnd = Math.min(end, cumulative);
+				if (binEnd > binStart) {
+					final long n = binEnd - binStart;
+					sumSqDiff += (value - m) * (value - m) * n;
+					clippedCount += n;
+				}
+			}
+
+			return clippedCount > 0 ? Math.sqrt(sumSqDiff / clippedCount) : 0.0;
+		}
+
+		private double valueAtRank(final long rank) {
+			long cumulative = 0;
+			for (int i = 0; i < counts.length; i++) {
+				cumulative += counts[i];
+				if (cumulative > rank) {
+					return i - offset;
+				}
+			}
+			// Return the last non-empty bin
+			return counts.length - 1 - offset;
 		}
 	}
 
@@ -308,18 +410,18 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 	 * Small helper enum to represent the type of mean used for normalization.
 	 */
 	protected enum ShiftType {
-		NONE(stats -> 0.0),
-		MEDIAN(stats -> stats.median),
-		MEAN(stats -> stats.mean);
+		NONE(h -> 0.0),
+		MEDIAN(h -> h.median()),
+		MEAN(h -> h.mean());
 
-		private final Function<LayerStats, Double> function;
+		private final Function<LayerHistogram, Double> function;
 
-		ShiftType(final Function<LayerStats, Double> function) {
+		ShiftType(final Function<LayerHistogram, Double> function) {
 			this.function = function;
 		}
 
-		public double from(final LayerStats stats) {
-			return function.apply(stats);
+		public double from(final LayerHistogram histogram) {
+			return function.apply(histogram);
 		}
 	}
 
@@ -329,18 +431,18 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 	 * 'GAUSS' scaling is what is used to normalize 8bit FIB-SEM data.
 	 */
 	protected enum ScaleType {
-		NONE(stats -> 1.0),
-		FULL_RANGE(stats -> stats.max - stats.min),
-		GAUSS(stats -> 4 * stats.std);
+		NONE(h -> 1.0),
+		FULL_RANGE(h -> h.max() - h.min()),
+		GAUSS(h -> 4 * h.std());
 
-		private final Function<LayerStats, Double> function;
+		private final Function<LayerHistogram, Double> function;
 
-		ScaleType(final Function<LayerStats, Double> function) {
+		ScaleType(final Function<LayerHistogram, Double> function) {
 			this.function = function;
 		}
 
-		public double get(final LayerStats stats) {
-			return function.apply(stats);
+		public double get(final LayerHistogram histogram) {
+			return function.apply(histogram);
 		}
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
@@ -97,10 +97,9 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 		 * Checks that output doesn't exist and input has valid attributes.
 		 *
 		 * @return the dataset attributes for the full scale input
-		 * @throws IOException if N5 access fails
 		 * @throws IllegalArgumentException if output exists or input has no attributes
 		 */
-		public DatasetAttributes readDatasetAttributes() throws IOException {
+		public DatasetAttributes readDatasetAttributes() {
 			try (final N5Reader n5reader = N5Util.createN5Reader(n5Path)) {
 				if (n5reader.exists(n5DatasetOutput)) {
 					throw new IllegalArgumentException("Normalized data set already exists: " + n5DatasetOutput);
@@ -126,8 +125,17 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 		public Integer downsampleLevel() {
 			return downsampleLevel;
 		}
-	}
 
+		@Override
+		public String toString() {
+			return "n5Path='" + n5Path + '\'' +
+				   ", n5DatasetInput='" + n5DatasetInput + '\'' +
+				   ", n5DatasetOutput='" + n5DatasetOutput + '\'' +
+				   ", downsampleLevel=" + downsampleLevel +
+				   ", factors='" + factors + '\'' +
+				   ", cutoff=" + cutoff;
+		}
+	}
 
 
 	protected final String fullScaleInputDataset;
@@ -147,9 +155,18 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 		this.typeHelper = typeHelper;
 	}
 
+	@Override
+	public String toString() {
+		return "fullScaleInputDataset='" + fullScaleInputDataset + '\'' +
+			   ", downScaledInputDataset='" + downScaledInputDataset + '\'' +
+			   ", fullScaleOutputDataset='" + fullScaleOutputDataset + '\'' +
+			   ", options=" + options +
+			   ", attributes=" + attributes.asMap();
+	}
+
 	protected void run() throws IOException {
 
-		logMessage("run: entry");
+		logMessage("run: entry, " + this);
 
 		// Read downscaled dataset attributes for grid creation and z-dimension validation
 		final DatasetAttributes downscaledAttributes;
@@ -441,8 +458,8 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 	 */
 	protected enum ShiftType {
 		NONE(h -> 0.0),
-		MEDIAN(h -> h.median()),
-		MEAN(h -> h.mean());
+		MEDIAN(LayerHistogram::median),
+		MEAN(LayerHistogram::mean);
 
 		private final Function<LayerHistogram, Double> function;
 

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
@@ -148,6 +148,9 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 	}
 
 	protected void run() throws IOException {
+
+		logMessage("run: entry");
+
 		// Read downscaled dataset attributes for grid creation and z-dimension validation
 		final DatasetAttributes downscaledAttributes;
 		try (final N5Reader n5reader = N5Util.createN5Reader(options.n5Path)) {
@@ -165,6 +168,8 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 			final List<AffineModel1D> transformations = computeTransformations(sparkContext, downscaledAttributes);
 			applyAndWrite(sparkContext, transformations);
 		}
+
+		logMessage("run: exit");
 	}
 
 	/**
@@ -172,6 +177,9 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 	 * optionally downsample, and transfer base attributes.
 	 */
 	private void applyAndWrite(final JavaSparkContext sparkContext, final List<AffineModel1D> transformations) throws IOException {
+
+		logMessage("applyAndWrite: entry, with " + transformations.size() + " transformations");
+
 		// Create output dataset
 		try (final N5Writer n5Writer = N5Util.createN5Writer(options.n5Path)) {
 			n5Writer.createDataset(fullScaleOutputDataset, attributes);
@@ -185,6 +193,7 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 
 		final int[] downsampleFactors = parseCSIntArray(options.factors);
 		if (downsampleFactors != null) {
+			logMessage("applyAndWrite: call downsampleScalePyramid");
 			downsampleScalePyramid(sparkContext,
 								   new N5PathSupplier(options.n5Path),
 								   fullScaleOutputDataset,
@@ -196,6 +205,8 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 		try (final N5Writer n5Writer = N5Util.createN5Writer(options.n5Path)) {
 			transferBaseAttributes(n5Writer);
 		}
+
+		logMessage("applyAndWrite: exit");
 	}
 
 
@@ -215,6 +226,9 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 			final RandomAccessibleInterval<T> sourceRaw,
 			final List<? extends AbstractAffineModel1D<?>> transformations
 	) {
+
+		logMessage("applyTransformations: entry, with " + transformations.size() + " transformations");
+
 		final List<IntervalView<T>> sourceStack = asZStack(sourceRaw);
 		final List<RandomAccessibleInterval<T>> convertedLayers = new ArrayList<>(sourceStack.size());
 		final double[] pixel = new double[1];
@@ -236,6 +250,8 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 
 			convertedLayers.add(convertedLayer);
 		}
+
+		logMessage("applyTransformations: exit, returning " + convertedLayers.size() + " converted layers");
 
 		return Views.stack(convertedLayers);
 	}
@@ -535,5 +551,9 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 			zScale *= factors[2];
 		}
 		n5Writer.setAttribute(options.n5DatasetOutput, "scales", scales);
+	}
+
+	private static void logMessage(final String message) {
+		org.janelia.saalfeldlab.hotknife.util.Util.logMessage(SparkNormalizeLayerIntensityN5.class.getName(), message);
 	}
 }

--- a/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
+++ b/src/main/java/org/janelia/saalfeldlab/hotknife/SparkNormalizeLayerIntensityN5.java
@@ -28,7 +28,6 @@ import net.imglib2.FinalInterval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converters;
 import net.imglib2.img.Img;
-import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
@@ -354,9 +353,8 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 	 */
 	protected interface TypeHelper<T extends NativeType<T> & IntegerType<T>> extends Serializable {
 		T getType();
-		Img<T> createImg(final long[] dimensions);
+
 		int clip(final int value);
-		boolean isOutsideThreshold(final int value);
 	}
 
 	protected static class ByteHelper implements TypeHelper<UnsignedByteType> {
@@ -366,19 +364,10 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 		}
 
 		@Override
-		public Img<UnsignedByteType> createImg(final long[] dimensions) {
-			return ArrayImgs.unsignedBytes(dimensions);
-		}
-
-		@Override
 		public int clip(final int value) {
 			return UnsignedByteType.getCodedSignedByteChecked(value);
 		}
 
-		@Override
-		public boolean isOutsideThreshold(final int value) {
-			return (value < 20 || value > 200);
-		}
 	}
 
 	protected static class ShortHelper implements TypeHelper<UnsignedShortType> {
@@ -388,19 +377,10 @@ public abstract class SparkNormalizeLayerIntensityN5<T extends NativeType<T> & I
 		}
 
 		@Override
-		public Img<UnsignedShortType> createImg(final long[] dimensions) {
-			return ArrayImgs.unsignedShorts(dimensions);
-		}
-
-		@Override
 		public int clip(final int value) {
 			return UnsignedShortType.getCodedSignedShortChecked(value);
 		}
 
-		@Override
-		public boolean isOutsideThreshold(final int value) {
-			return (value < 5000 || value > 60000);
-		}
 	}
 
 	/**


### PR DESCRIPTION
Layer-wise normalization consists of two phases:
1. read a downsampled version of the stack to compute the layer-wise intensity transformations
2. apply the intensity transformations and resave the full-scale stack

This PR adds parallelization to the first phase (the second phase was already parallelized over chunks):
  - Refactor LayerStats into LayerHistogram: stores an integer histogram instead of a sorted array, computes statistics on demand, and supports merging via absorb(). This is necessary to support the `MEDIAN` option for intensity shifts.
  - Parallelize phase 1 (histogram computation) of both MultiSemNormalizeLayerIntensity and FibSemNormalizeLayerIntensity using Spark mapPartitions.
  - Unify run() in the base class: creates SparkContext, calls computeTransformations(sparkContext, downscaledAttributes), then applyAndWrite().
  - MultiSem uses per-XY-column parallelization (full z-extent per task); FibSem uses per-3D-chunk. This reflects the usual shape of datasets (wide and flat vs. narrow and tall, respectively).  
